### PR TITLE
Warpscan Updates

### DIFF
--- a/domain/include/cstone/primitives/warpscan.cuh
+++ b/domain/include/cstone/primitives/warpscan.cuh
@@ -23,6 +23,17 @@
 namespace cstone
 {
 
+__device__ __forceinline__ unsigned laneIndex()
+{
+#ifdef __CUDACC__
+    unsigned laneIdx;
+    asm volatile("mov.u32 %0, %laneid;" : "=r"(laneIdx));
+    return laneIdx;
+#else
+    return (threadIdx.z * blockDim.y * blockDim.x + threadIdx.y * blockDim.x + threadIdx.x) & (GpuConfig::warpSize - 1);
+#endif
+}
+
 //! @brief there's no int overload for min in AMD ROCM
 __device__ __forceinline__ int imin(int a, int b) { return a < b ? a : b; }
 __device__ __forceinline__ unsigned imin(unsigned a, unsigned b) { return a < b ? a : b; }

--- a/domain/include/cstone/primitives/warpscan.cuh
+++ b/domain/include/cstone/primitives/warpscan.cuh
@@ -144,7 +144,7 @@ __device__ __forceinline__ T warpMax(T laneVal)
 //! @brief standard inclusive warp-scan
 __device__ __forceinline__ int inclusiveScanInt(int value)
 {
-    unsigned lane = threadIdx.x & (GpuConfig::warpSize - 1);
+    unsigned lane = laneIndex();
 #pragma unroll
     for (int i = 1; i < GpuConfig::warpSize; i *= 2)
     {
@@ -157,7 +157,7 @@ __device__ __forceinline__ int inclusiveScanInt(int value)
 //! @brief returns a mask with bits set for each warp lane before the calling lane
 __device__ __forceinline__ GpuConfig::ThreadMask lanemask_lt()
 {
-    GpuConfig::ThreadMask lane = threadIdx.x & (GpuConfig::warpSize - 1);
+    GpuConfig::ThreadMask lane = laneIndex();
     return (GpuConfig::ThreadMask(1) << lane) - 1;
 }
 
@@ -180,7 +180,7 @@ __device__ __forceinline__ int reduceBool(const bool p)
 //! @brief returns a mask with bits set for each warp lane before and including the calling lane
 __device__ __forceinline__ GpuConfig::ThreadMask lanemask_le()
 {
-    GpuConfig::ThreadMask lane = threadIdx.x & (GpuConfig::warpSize - 1);
+    GpuConfig::ThreadMask lane = laneIndex();
     return (GpuConfig::ThreadMask(2) << lane) - 1;
 }
 
@@ -218,7 +218,7 @@ __device__ __forceinline__ int inclusiveSegscan(int value, int distance)
  */
 __device__ __forceinline__ int inclusiveSegscanInt(const int packedValue, const int carryValue)
 {
-    int laneIdx = int(threadIdx.x) & (GpuConfig::warpSize - 1);
+    int laneIdx = laneIndex();
 
     int isNegative = packedValue < 0;
     int mask       = -isNegative;
@@ -269,7 +269,7 @@ __device__ __forceinline__ int streamCompact(T* value, bool keep, volatile T* sm
     if (keep) { sm_exchange[laneCompacted] = *value; }
     syncWarp();
 
-    int laneIdx = threadIdx.x & (GpuConfig::warpSize - 1);
+    int laneIdx = laneIndex();
     *value      = sm_exchange[laneIdx];
 
     int numKeep = popCount(SignedMask(keepBallot));
@@ -284,7 +284,7 @@ __device__ __forceinline__ int streamCompact(T* value, bool keep, volatile T* sm
  */
 __device__ __forceinline__ int spreadSeg8(int val)
 {
-    int laneIdx = int(threadIdx.x) & (GpuConfig::warpSize - 1);
+    int laneIdx = laneIndex();
     return shflSync(val, laneIdx >> 3) + (laneIdx & 7);
 }
 

--- a/domain/include/cstone/primitives/warpscan.cuh
+++ b/domain/include/cstone/primitives/warpscan.cuh
@@ -63,48 +63,104 @@ __device__ __forceinline__ void syncWarp()
 #endif
 }
 
+namespace detail
+{
+
+template<class T, class = void>
+struct IsHardwareShuffleable : std::false_type
+{
+};
+
+template<class T>
+struct IsHardwareShuffleable<T,
+                             std::void_t<decltype(
+#if defined(__CUDACC__) && !defined(__HIPCC__)
+                                 __shfl_sync(0xFFFFFFFF, std::declval<T>(), 0, 0)
+#else
+                                 __shfl(std::declval<T>(), 0)
+#endif
+                                     )>> : std::true_type
+{
+};
+
+template<class T, class Op>
+__device__ __forceinline__ T shflSyncImpl(T value, Op&& shflOp)
+{
+    if constexpr (detail::IsHardwareShuffleable<T>::value) { return shflOp(value); }
+    else
+    {
+        static_assert(std::is_trivially_copyable_v<T>);
+        constexpr int numInts = (sizeof(T) + sizeof(int) - 1) / sizeof(int);
+        int buffer[numInts];
+        memcpy(buffer, &value, sizeof(value));
+#pragma unroll
+        for (int i = 0; i < numInts; ++i)
+            buffer[i] = shflOp(buffer[i]);
+        memcpy(&value, buffer, sizeof(value));
+        return value;
+    }
+}
+
+} // namespace detail
+
 //! @brief Compatibility wrapper for AMD.
 template<class T>
 __device__ __forceinline__ T shflSync(T value, int srcLane)
 {
+    return detail::shflSyncImpl(value,
+                                [=](auto v)
+                                {
 #if defined(__CUDACC__) && !defined(__HIPCC__)
-    return __shfl_sync(0xFFFFFFFF, value, srcLane);
+                                    return __shfl_sync(0xFFFFFFFF, v, srcLane);
 #else
-    return __shfl(value, srcLane);
+                                    return __shfl(v, srcLane);
 #endif
+                                });
 }
 
 //! @brief Compatibility wrapper for AMD.
 template<class T>
 __device__ __forceinline__ T shflXorSync(T value, int width)
 {
+    return detail::shflSyncImpl(value,
+                                [=](auto v)
+                                {
 #if defined(__CUDACC__) && !defined(__HIPCC__)
-    return __shfl_xor_sync(0xFFFFFFFF, value, width);
+                                    return __shfl_xor_sync(0xFFFFFFFF, v, width);
 #else
-    return __shfl_xor(value, width);
+                                    return __shfl_xor(v, width);
 #endif
+                                });
 }
 
 //! @brief Compatibility wrapper for AMD.
 template<class T>
 __device__ __forceinline__ T shflUpSync(T value, int distance)
 {
+    return detail::shflSyncImpl(value,
+                                [=](auto v)
+                                {
 #if defined(__CUDACC__) && !defined(__HIPCC__)
-    return __shfl_up_sync(0xFFFFFFFF, value, distance);
+                                    return __shfl_up_sync(0xFFFFFFFF, v, distance);
 #else
-    return __shfl_up(value, distance);
+                                    return __shfl_up(v, distance);
 #endif
+                                });
 }
 
 //! @brief Compatibility wrapper for AMD.
 template<class T>
 __device__ __forceinline__ T shflDownSync(T value, int distance)
 {
+    return detail::shflSyncImpl(value,
+                                [=](auto v)
+                                {
 #if defined(__CUDACC__) && !defined(__HIPCC__)
-    return __shfl_down_sync(0xFFFFFFFF, value, distance);
+                                    return __shfl_down_sync(0xFFFFFFFF, v, distance);
 #else
-    return __shfl_down(value, distance);
+                                    return __shfl_down(v, distance);
 #endif
+                                });
 }
 
 //! @brief Compatibility wrapper for AMD.

--- a/domain/include/cstone/primitives/warpscan.cuh
+++ b/domain/include/cstone/primitives/warpscan.cuh
@@ -173,6 +173,16 @@ __device__ __forceinline__ GpuConfig::ThreadMask ballotSync(bool flag)
 #endif
 }
 
+//! @brief Compatibility wrapper for AMD.
+__device__ __forceinline__ GpuConfig::ThreadMask anySync(bool flag)
+{
+#if defined(__CUDACC__) && !defined(__HIPCC__)
+    return __any_sync(0xFFFFFFFF, flag);
+#else
+    return __any(flag);
+#endif
+}
+
 //! @brief compute warp-wide min
 template<class T>
 __device__ __forceinline__ T warpMin(T laneVal)

--- a/domain/include/cstone/primitives/warpscan.cuh
+++ b/domain/include/cstone/primitives/warpscan.cuh
@@ -209,6 +209,19 @@ __device__ __forceinline__ T warpMax(T laneVal)
     return laneVal;
 }
 
+//! @brief compute warp-wide bitwise or
+template<class T>
+__device__ __forceinline__ T warpBitwiseOr(T laneVal)
+{
+#pragma unroll
+    for (int i = 0; i < GpuConfig::warpSizeLog2; i++)
+    {
+        laneVal |= shflXorSync(laneVal, 1 << i);
+    }
+
+    return laneVal;
+}
+
 //! @brief standard inclusive warp-scan
 __device__ __forceinline__ int inclusiveScanInt(int value)
 {

--- a/domain/include/cstone/primitives/warpscan.cuh
+++ b/domain/include/cstone/primitives/warpscan.cuh
@@ -56,8 +56,10 @@ __device__ __forceinline__ int popCount(T x)
 
 __device__ __forceinline__ void syncWarp()
 {
-#if defined(__CUDACC__) && !defined(__HIPCC__)
+#if defined(__CUDACC__)
     __syncwarp();
+#elif defined(__HIP_PLATFORM_AMD__)
+    __builtin_amdgcn_fence(__ATOMIC_ACQ_REL, "agent");
 #endif
 }
 

--- a/domain/include/cstone/primitives/warpscan.cuh
+++ b/domain/include/cstone/primitives/warpscan.cuh
@@ -120,15 +120,15 @@ __device__ __forceinline__ T shflSync(T value, int srcLane)
 
 //! @brief Compatibility wrapper for AMD.
 template<class T>
-__device__ __forceinline__ T shflXorSync(T value, int width)
+__device__ __forceinline__ T shflXorSync(T value, int laneMask)
 {
     return detail::shflSyncImpl(value,
                                 [=](auto v)
                                 {
 #if defined(__CUDACC__) && !defined(__HIPCC__)
-                                    return __shfl_xor_sync(0xFFFFFFFF, v, width);
+                                    return __shfl_xor_sync(0xFFFFFFFF, v, laneMask);
 #else
-                                    return __shfl_xor(v, width);
+                                    return __shfl_xor(v, laneMask);
 #endif
                                 });
 }

--- a/domain/include/cstone/primitives/warpscan.cuh
+++ b/domain/include/cstone/primitives/warpscan.cuh
@@ -83,6 +83,15 @@ struct IsHardwareShuffleable<T,
 {
 };
 
+static_assert(IsHardwareShuffleable<int>::value);
+static_assert(IsHardwareShuffleable<unsigned>::value);
+static_assert(IsHardwareShuffleable<long>::value);
+static_assert(IsHardwareShuffleable<unsigned long>::value);
+static_assert(IsHardwareShuffleable<long long>::value);
+static_assert(IsHardwareShuffleable<unsigned long long>::value);
+static_assert(IsHardwareShuffleable<float>::value);
+static_assert(IsHardwareShuffleable<double>::value);
+
 template<class T, class Op>
 __device__ __forceinline__ T shflSyncImpl(T value, Op&& shflOp)
 {

--- a/domain/test/unit_cuda/primitives/warpscan.cu
+++ b/domain/test/unit_cuda/primitives/warpscan.cu
@@ -254,7 +254,7 @@ struct WarpBallotSync
     {
         GpuConfig::ThreadMask result = 0;
         for (std::size_t i = 0; i < output.size(); ++i)
-            result |= input[i] << i;
+            result |= GpuConfig::ThreadMask(input[i]) << i;
         std::ranges::fill(output, result);
     };
 };

--- a/domain/test/unit_cuda/primitives/warpscan.cu
+++ b/domain/test/unit_cuda/primitives/warpscan.cu
@@ -74,6 +74,7 @@ std::ostream& operator<<(std::ostream& out, SomeStruct const& s)
 template<class T>
 std::tuple<dim3, dim3, thrust::host_vector<T>> testData()
 {
+    // Note: we use 3D thread blocks here to test proper lane indexing in multi-D blocks (test data is still 1D)
     const dim3 numBlocks = {5, 2, 3};
     const dim3 blockSize = {GpuConfig::warpSize / 4, 2, 6};
 

--- a/domain/test/unit_cuda/primitives/warpscan.cu
+++ b/domain/test/unit_cuda/primitives/warpscan.cu
@@ -139,7 +139,7 @@ void verifyWarpCollectiveFunctionOutput(thrust::host_vector<InputT> const& input
 }
 
 /* Helper to test warp-collective functions on the GPU. InputT/OutputT are per-thread input/output types
- * The functor f provides a reference implementation on the host to the against. It must:
+ * The functor f provides a reference implementation for a single warp on the host to test against. It must:
  * - be a device-callable functor, taking a single argument,
  * - have static member F::reference which is a functor with signature
  *   (WarpSpan<const InputT>, WarpSpan<OutputT>) -> void.

--- a/domain/test/unit_cuda/primitives/warpscan.cu
+++ b/domain/test/unit_cuda/primitives/warpscan.cu
@@ -16,6 +16,7 @@
 #include "gtest/gtest.h"
 
 #include <algorithm>
+#include <functional>
 #include <random>
 #include <ranges>
 #include <span>
@@ -43,23 +44,51 @@ __global__ void applyWarpFunction(InputT* const input, OutputT* output, F f)
     output[index]        = f(input[index]);
 }
 
+struct SomeStruct
+{
+    int a;
+    float b;
+    double c;
+    bool d;
+
+    bool operator==(SomeStruct const& other) const
+    {
+        return a == other.a && b == other.b && c == other.c && d == other.d;
+    }
+};
+
 template<class T>
 std::tuple<dim3, dim3, thrust::host_vector<T>> testData()
 {
     const dim3 numBlocks = {5, 2, 3};
     const dim3 blockSize = {GpuConfig::warpSize / 4, 2, 6};
 
-    thrust::host_vector<T> data(blockSize.x * blockSize.y * blockSize.z * numBlocks.x * numBlocks.y * numBlocks.z,
-                                T(0));
-    std::fill(data.begin() + GpuConfig::warpSize, data.begin() + GpuConfig::warpSize * 2, T(1));
+    thrust::host_vector<T> data(blockSize.x * blockSize.y * blockSize.z * numBlocks.x * numBlocks.y * numBlocks.z, T{});
 
-    using Dist = std::conditional_t<
-        std::is_floating_point_v<T>, std::uniform_real_distribution<T>,
-        std::conditional_t<std::is_same_v<T, bool>, std::bernoulli_distribution, std::uniform_int_distribution<T>>>;
-
-    Dist dist;
     std::default_random_engine eng;
-    std::generate(data.begin() + GpuConfig::warpSize * 2, data.end(), std::bind(dist, std::ref(eng)));
+    if constexpr (std::is_same_v<T, SomeStruct>)
+    {
+        using IntDist    = std::uniform_int_distribution<int>;
+        using FloatDist  = std::uniform_real_distribution<float>;
+        using DoubleDist = std::uniform_real_distribution<double>;
+        using BoolDist   = std::bernoulli_distribution;
+
+        auto randomInt    = std::bind(IntDist{}, std::ref(eng));
+        auto randomFloat  = std::bind(FloatDist{}, std::ref(eng));
+        auto randomDouble = std::bind(DoubleDist{}, std::ref(eng));
+        auto randomBool   = std::bind(BoolDist{}, std::ref(eng));
+
+        std::generate(data.begin(), data.end() - GpuConfig::warpSize,
+                      [&] { return SomeStruct{randomInt(), randomFloat(), randomDouble(), randomBool()}; });
+    }
+    else
+    {
+        using Dist = std::conditional_t<
+            std::is_floating_point_v<T>, std::uniform_real_distribution<T>,
+            std::conditional_t<std::is_same_v<T, bool>, std::bernoulli_distribution, std::uniform_int_distribution<T>>>;
+
+        std::generate(data.begin(), data.end() - GpuConfig::warpSize, std::bind(Dist{}, std::ref(eng)));
+    }
 
     return {std::move(numBlocks), std::move(blockSize), std::move(data)};
 }
@@ -95,6 +124,148 @@ void testOnDevice(F f)
 
     EXPECT_EQ(output, reference);
 }
+
+struct WarpLaneIndex
+{
+    __device__ unsigned operator()(unsigned) const { return laneIndex(); }
+
+    static constexpr auto reference = [](auto input, auto output) { std::iota(output.begin(), output.end(), 0u); };
+};
+
+TEST(WarpScan, laneIndex) { testOnDevice<unsigned>(WarpLaneIndex{}); }
+
+template<int Src>
+struct WarpShflSync
+{
+    template<class T>
+    __device__ T operator()(T x) const
+    {
+        return shflSync(x, Src);
+    };
+
+    static constexpr auto reference = [](auto input, auto output) { std::ranges::fill(output, input[Src]); };
+};
+
+TEST(WarpScan, shflSync)
+{
+    testOnDevice<int>(WarpShflSync<GpuConfig::warpSize / 10>{});
+    testOnDevice<int>(WarpShflSync<GpuConfig::warpSize - 1>{});
+    testOnDevice<float>(WarpShflSync<GpuConfig::warpSize / 3>{});
+    testOnDevice<float>(WarpShflSync<GpuConfig::warpSize - 1>{});
+    testOnDevice<double>(WarpShflSync<GpuConfig::warpSize / 7>{});
+    testOnDevice<double>(WarpShflSync<GpuConfig::warpSize - 1>{});
+    testOnDevice<SomeStruct>(WarpShflSync<GpuConfig::warpSize / 2>{});
+    testOnDevice<SomeStruct>(WarpShflSync<GpuConfig::warpSize - 1>{});
+}
+
+template<GpuConfig::ThreadMask LaneMask>
+struct WarpShflXorSync
+{
+    template<class T>
+    __device__ T operator()(T x) const
+    {
+        return shflXorSync(x, LaneMask);
+    };
+
+    static constexpr auto reference = [](auto input, auto output)
+    {
+        for (std::size_t i = 0; i < output.size(); ++i)
+            output[i] = input[i ^ LaneMask];
+    };
+};
+
+TEST(WarpScan, shflXorSync)
+{
+    testOnDevice<int>(WarpShflXorSync<2>{});
+    testOnDevice<int>(WarpShflXorSync<4>{});
+    testOnDevice<float>(WarpShflXorSync<8>{});
+    testOnDevice<float>(WarpShflXorSync<16>{});
+    testOnDevice<double>(WarpShflXorSync<2>{});
+    testOnDevice<double>(WarpShflXorSync<4>{});
+    testOnDevice<SomeStruct>(WarpShflXorSync<8>{});
+    testOnDevice<SomeStruct>(WarpShflXorSync<16>{});
+}
+
+template<unsigned Delta>
+struct WarpShflUpSync
+{
+    template<class T>
+    __device__ T operator()(T x) const
+    {
+        return shflUpSync(x, Delta);
+    };
+
+    static constexpr auto reference = [](auto input, auto output)
+    {
+        std::copy_n(input.begin(), Delta, output.begin());
+        std::copy_n(input.begin(), GpuConfig::warpSize - Delta, output.begin() + Delta);
+    };
+};
+
+TEST(WarpScan, shflUpSync)
+{
+    testOnDevice<int>(WarpShflUpSync<1>{});
+    testOnDevice<int>(WarpShflUpSync<2>{});
+    testOnDevice<float>(WarpShflUpSync<3>{});
+    testOnDevice<float>(WarpShflUpSync<4>{});
+    testOnDevice<double>(WarpShflUpSync<5>{});
+    testOnDevice<double>(WarpShflUpSync<6>{});
+    testOnDevice<SomeStruct>(WarpShflUpSync<7>{});
+    testOnDevice<SomeStruct>(WarpShflUpSync<8>{});
+}
+
+template<unsigned Delta>
+struct WarpShflDownSync
+{
+    template<class T>
+    __device__ T operator()(T x) const
+    {
+        return shflDownSync(x, Delta);
+    };
+
+    static constexpr auto reference = [](auto input, auto output)
+    {
+        std::copy_n(input.begin() + Delta, GpuConfig::warpSize - Delta, output.begin());
+        std::copy_n(input.end() - Delta, Delta, output.end() - Delta);
+    };
+};
+
+TEST(WarpScan, shflDownSync)
+{
+    testOnDevice<int>(WarpShflDownSync<1>{});
+    testOnDevice<int>(WarpShflDownSync<2>{});
+    testOnDevice<float>(WarpShflDownSync<3>{});
+    testOnDevice<float>(WarpShflDownSync<4>{});
+    testOnDevice<double>(WarpShflDownSync<5>{});
+    testOnDevice<double>(WarpShflDownSync<6>{});
+    testOnDevice<SomeStruct>(WarpShflDownSync<7>{});
+    testOnDevice<SomeStruct>(WarpShflDownSync<8>{});
+}
+
+struct WarpBallotSync
+{
+    __device__ GpuConfig::ThreadMask operator()(bool x) const { return ballotSync(x); };
+
+    static constexpr auto reference = [](auto input, auto output)
+    {
+        GpuConfig::ThreadMask result = 0;
+        for (std::size_t i = 0; i < output.size(); ++i)
+            result |= input[i] << i;
+        std::ranges::fill(output, result);
+    };
+};
+
+TEST(WarpScan, ballotSync) { testOnDevice<bool, GpuConfig::ThreadMask>(WarpBallotSync{}); }
+
+struct WarpAnySync
+{
+    __device__ bool operator()(bool x) const { return anySync(x); };
+
+    static constexpr auto reference = [](auto input, auto output)
+    { std::ranges::fill(output, std::accumulate(input.begin(), input.end(), false, std::logical_or<bool>{})); };
+};
+
+TEST(WarpScan, anySync) { testOnDevice<bool>(WarpAnySync{}); }
 
 struct WarpMin
 {
@@ -134,6 +305,27 @@ TEST(WarpScan, warpMax)
     testOnDevice<double>(WarpMax{});
 }
 
+struct WarpBitwiseOr
+{
+    template<class T>
+    __device__ T operator()(T x) const
+    {
+        return warpBitwiseOr(x);
+    }
+
+    static constexpr auto reference = [](auto input, auto output)
+    {
+        using T = decltype(output)::value_type;
+        std::ranges::fill(output, std::accumulate(input.begin(), input.end(), T(0), std::bit_or<T>{}));
+    };
+};
+
+TEST(WarpScan, warpBitwiseOr)
+{
+    testOnDevice<int>(WarpBitwiseOr{});
+    testOnDevice<unsigned>(WarpBitwiseOr{});
+}
+
 struct WarpInclusiveScanInt
 {
     __device__ int operator()(int x) const { return inclusiveScanInt(x); }
@@ -153,6 +345,16 @@ struct WarpExclusiveScanBool
 };
 
 TEST(WarpScan, exclusiveScanBool) { testOnDevice<bool, int>(WarpExclusiveScanBool{}); }
+
+struct WarpReduceBool
+{
+    __device__ int operator()(bool x) const { return reduceBool(x); }
+
+    static constexpr auto reference = [](auto input, auto output)
+    { std::ranges::fill(output, std::accumulate(input.begin(), input.end(), 0)); };
+};
+
+TEST(WarpScan, reduceBool) { testOnDevice<bool, int>(WarpReduceBool{}); }
 
 template<int Carry>
 struct WarpInclusiveSegscanInt

--- a/domain/test/unit_cuda/primitives/warpscan.cu
+++ b/domain/test/unit_cuda/primitives/warpscan.cu
@@ -46,7 +46,7 @@ __device__ unsigned globalIndex()
 }
 
 template<class InputT, class OutputT = InputT, class F>
-__global__ void applyWarpFunction(InputT* const input, OutputT* output, F f)
+__global__ void applyWarpCollectiveFunction(InputT* const input, OutputT* output, F f)
 {
     const unsigned index = globalIndex();
     output[index]        = f(input[index]);
@@ -72,7 +72,7 @@ std::ostream& operator<<(std::ostream& out, SomeStruct const& s)
 }
 
 template<class T>
-std::tuple<dim3, dim3, thrust::host_vector<T>> testData()
+std::tuple<dim3, dim3, thrust::host_vector<T>> warpCollectiveFunctionTestData()
 {
     // Note: we use 3D thread blocks here to test proper lane indexing in multi-D blocks (test data is still 1D)
     const dim3 numBlocks = {5, 2, 3};
@@ -112,7 +112,9 @@ template<class T>
 using WarpSpan = std::span<T, GpuConfig::warpSize>;
 
 template<class InputT, class OutputT, class WarpF>
-void verify(thrust::host_vector<InputT> const& input, WarpF warpF, thrust::host_vector<OutputT> const& output)
+void verifyWarpCollectiveFunctionOutput(thrust::host_vector<InputT> const& input,
+                                        WarpF warpF,
+                                        thrust::host_vector<OutputT> const& output)
 {
     ASSERT_EQ(input.size(), output.size());
     ASSERT_EQ(input.size() % GpuConfig::warpSize, 0);
@@ -136,25 +138,31 @@ void verify(thrust::host_vector<InputT> const& input, WarpF warpF, thrust::host_
     }
 }
 
+/* Helper to test warp-collective functions on the GPU. InputT/OutputT are per-thread input/output types
+ * The functor f provides a reference implementation on the host to the against. It must:
+ * - be a device-callable functor, taking a single argument,
+ * - have static member F::reference which is a functor with signature
+ *   (WarpSpan<const InputT>, WarpSpan<OutputT>) -> void.
+ */
 template<class InputT, class OutputT = InputT, class F>
 void testWarpCollectiveFunction(F f)
 {
-    const auto [numBlocks, blockSize, input] = testData<InputT>();
+    const auto [numBlocks, blockSize, input] = warpCollectiveFunctionTestData<InputT>();
 
     thrust::device_vector<InputT> deviceInput = input;
     thrust::device_vector<OutputT> deviceOutput(input.size());
-    applyWarpFunction<<<numBlocks, blockSize>>>(rawPtr(deviceInput), rawPtr(deviceOutput), f);
+    applyWarpCollectiveFunction<<<numBlocks, blockSize>>>(rawPtr(deviceInput), rawPtr(deviceOutput), f);
     checkGpuErrors(cudaDeviceSynchronize());
 
     thrust::host_vector<OutputT> output = deviceOutput;
-    verify(input, F::reference, output);
+    verifyWarpCollectiveFunctionOutput(input, F::reference, output);
 }
 
 struct WarpLaneIndex
 {
     __device__ unsigned operator()(unsigned /* unused */) const { return laneIndex(); }
 
-    static constexpr auto reference = [](WarpSpan<const unsigned> /* input */, WarpSpan<unsigned> output)
+    static constexpr auto reference = [](WarpSpan<const unsigned> /* unused */, WarpSpan<unsigned> output)
     { std::iota(output.begin(), output.end(), 0u); };
 };
 

--- a/domain/test/unit_cuda/primitives/warpscan.cu
+++ b/domain/test/unit_cuda/primitives/warpscan.cu
@@ -16,12 +16,15 @@
 #include "gtest/gtest.h"
 
 #include <algorithm>
+#include <array>
 #include <cstddef>
 #include <functional>
+#include <iomanip>
 #include <numeric>
 #include <random>
 #include <ranges>
-#include <span>
+#include <ranges>
+#include <sstream>
 #include <tuple>
 #include <type_traits>
 #include <utility>
@@ -60,6 +63,11 @@ struct SomeStruct
         return a == other.a && b == other.b && c == other.c && d == other.d;
     }
 };
+
+std::ostream& operator<<(std::ostream& out, SomeStruct const& s) {
+    out << "SomeStruct {" << s.a << ", " << s.b << ", " << s.c << ", " << s.d << "}";
+    return out;
+}
 
 template<class T>
 std::tuple<dim3, dim3, thrust::host_vector<T>> testData()
@@ -101,16 +109,26 @@ template<class T>
 using WarpSpan = std::span<T, GpuConfig::warpSize>;
 
 template<class InputT, class OutputT, class WarpF>
-thrust::host_vector<OutputT> computeReference(thrust::host_vector<InputT> const& input, WarpF warpF)
+void verify(thrust::host_vector<InputT> const& input, WarpF warpF, thrust::host_vector<OutputT> const& output)
 {
-    thrust::host_vector<OutputT> output(input.size());
+    ASSERT_EQ(input.size(), output.size());
+    ASSERT_EQ(input.size() % GpuConfig::warpSize, 0);
     for (std::size_t warp = 0; warp < input.size() / GpuConfig::warpSize; ++warp)
     {
         WarpSpan<const InputT> warpInput(&input[warp * GpuConfig::warpSize], &input[(warp + 1) * GpuConfig::warpSize]);
-        WarpSpan<OutputT> warpOutput(&output[warp * GpuConfig::warpSize], &output[(warp + 1) * GpuConfig::warpSize]);
-        warpF(warpInput, warpOutput);
+        WarpSpan<const OutputT> warpOutput(&output[warp * GpuConfig::warpSize], &output[(warp + 1) * GpuConfig::warpSize]);
+        std::array<OutputT, GpuConfig::warpSize> expectedWarpOutput;
+
+        warpF(warpInput, WarpSpan<OutputT>(expectedWarpOutput));
+
+        if (!std::ranges::equal(warpOutput, expectedWarpOutput)) {
+            std::ostringstream failures;
+            for (unsigned i = 0; i < GpuConfig::warpSize; ++i)
+                failures << "Lane " << std::setw(2) << i << " - input: " << warpInput[i] << ", output: " << warpOutput[i] << ", expected output: " << expectedWarpOutput[i] << "\n";
+
+            ADD_FAILURE() << failures.view();
+        }
     }
-    return output;
 }
 
 template<class InputT, class OutputT = InputT, class F>
@@ -123,10 +141,8 @@ void testOnDevice(F f)
     applyWarpFunction<<<numBlocks, blockSize>>>(rawPtr(deviceInput), rawPtr(deviceOutput), f);
     checkGpuErrors(cudaDeviceSynchronize());
 
-    thrust::host_vector<OutputT> reference = computeReference<InputT, OutputT>(input, F::reference);
-    thrust::host_vector<OutputT> output    = deviceOutput;
-
-    EXPECT_EQ(output, reference);
+    thrust::host_vector<OutputT> output = deviceOutput;
+    verify(input, F::reference, output);
 }
 
 struct WarpLaneIndex

--- a/domain/test/unit_cuda/primitives/warpscan.cu
+++ b/domain/test/unit_cuda/primitives/warpscan.cu
@@ -137,7 +137,7 @@ void verify(thrust::host_vector<InputT> const& input, WarpF warpF, thrust::host_
 }
 
 template<class InputT, class OutputT = InputT, class F>
-void testOnDevice(F f)
+void testWarpCollectiveFunction(F f)
 {
     const auto [numBlocks, blockSize, input] = testData<InputT>();
 
@@ -158,7 +158,7 @@ struct WarpLaneIndex
     { std::iota(output.begin(), output.end(), 0u); };
 };
 
-TEST(WarpScan, laneIndex) { testOnDevice<unsigned>(WarpLaneIndex{}); }
+TEST(WarpScan, laneIndex) { testWarpCollectiveFunction<unsigned>(WarpLaneIndex{}); }
 
 template<int Src>
 struct WarpShflSync
@@ -175,14 +175,14 @@ struct WarpShflSync
 
 TEST(WarpScan, shflSync)
 {
-    testOnDevice<int>(WarpShflSync<GpuConfig::warpSize / 10>{});
-    testOnDevice<int>(WarpShflSync<GpuConfig::warpSize - 1>{});
-    testOnDevice<float>(WarpShflSync<GpuConfig::warpSize / 3>{});
-    testOnDevice<float>(WarpShflSync<GpuConfig::warpSize - 1>{});
-    testOnDevice<double>(WarpShflSync<GpuConfig::warpSize / 7>{});
-    testOnDevice<double>(WarpShflSync<GpuConfig::warpSize - 1>{});
-    testOnDevice<SomeStruct>(WarpShflSync<GpuConfig::warpSize / 2>{});
-    testOnDevice<SomeStruct>(WarpShflSync<GpuConfig::warpSize - 1>{});
+    testWarpCollectiveFunction<int>(WarpShflSync<GpuConfig::warpSize / 10>{});
+    testWarpCollectiveFunction<int>(WarpShflSync<GpuConfig::warpSize - 1>{});
+    testWarpCollectiveFunction<float>(WarpShflSync<GpuConfig::warpSize / 3>{});
+    testWarpCollectiveFunction<float>(WarpShflSync<GpuConfig::warpSize - 1>{});
+    testWarpCollectiveFunction<double>(WarpShflSync<GpuConfig::warpSize / 7>{});
+    testWarpCollectiveFunction<double>(WarpShflSync<GpuConfig::warpSize - 1>{});
+    testWarpCollectiveFunction<SomeStruct>(WarpShflSync<GpuConfig::warpSize / 2>{});
+    testWarpCollectiveFunction<SomeStruct>(WarpShflSync<GpuConfig::warpSize - 1>{});
 }
 
 template<GpuConfig::ThreadMask LaneMask>
@@ -203,14 +203,14 @@ struct WarpShflXorSync
 
 TEST(WarpScan, shflXorSync)
 {
-    testOnDevice<int>(WarpShflXorSync<2>{});
-    testOnDevice<int>(WarpShflXorSync<4>{});
-    testOnDevice<float>(WarpShflXorSync<8>{});
-    testOnDevice<float>(WarpShflXorSync<16>{});
-    testOnDevice<double>(WarpShflXorSync<2>{});
-    testOnDevice<double>(WarpShflXorSync<4>{});
-    testOnDevice<SomeStruct>(WarpShflXorSync<8>{});
-    testOnDevice<SomeStruct>(WarpShflXorSync<16>{});
+    testWarpCollectiveFunction<int>(WarpShflXorSync<2>{});
+    testWarpCollectiveFunction<int>(WarpShflXorSync<4>{});
+    testWarpCollectiveFunction<float>(WarpShflXorSync<8>{});
+    testWarpCollectiveFunction<float>(WarpShflXorSync<16>{});
+    testWarpCollectiveFunction<double>(WarpShflXorSync<2>{});
+    testWarpCollectiveFunction<double>(WarpShflXorSync<4>{});
+    testWarpCollectiveFunction<SomeStruct>(WarpShflXorSync<8>{});
+    testWarpCollectiveFunction<SomeStruct>(WarpShflXorSync<16>{});
 }
 
 template<unsigned Delta>
@@ -231,14 +231,14 @@ struct WarpShflUpSync
 
 TEST(WarpScan, shflUpSync)
 {
-    testOnDevice<int>(WarpShflUpSync<1>{});
-    testOnDevice<int>(WarpShflUpSync<2>{});
-    testOnDevice<float>(WarpShflUpSync<3>{});
-    testOnDevice<float>(WarpShflUpSync<4>{});
-    testOnDevice<double>(WarpShflUpSync<5>{});
-    testOnDevice<double>(WarpShflUpSync<6>{});
-    testOnDevice<SomeStruct>(WarpShflUpSync<7>{});
-    testOnDevice<SomeStruct>(WarpShflUpSync<8>{});
+    testWarpCollectiveFunction<int>(WarpShflUpSync<1>{});
+    testWarpCollectiveFunction<int>(WarpShflUpSync<2>{});
+    testWarpCollectiveFunction<float>(WarpShflUpSync<3>{});
+    testWarpCollectiveFunction<float>(WarpShflUpSync<4>{});
+    testWarpCollectiveFunction<double>(WarpShflUpSync<5>{});
+    testWarpCollectiveFunction<double>(WarpShflUpSync<6>{});
+    testWarpCollectiveFunction<SomeStruct>(WarpShflUpSync<7>{});
+    testWarpCollectiveFunction<SomeStruct>(WarpShflUpSync<8>{});
 }
 
 template<unsigned Delta>
@@ -259,14 +259,14 @@ struct WarpShflDownSync
 
 TEST(WarpScan, shflDownSync)
 {
-    testOnDevice<int>(WarpShflDownSync<1>{});
-    testOnDevice<int>(WarpShflDownSync<2>{});
-    testOnDevice<float>(WarpShflDownSync<3>{});
-    testOnDevice<float>(WarpShflDownSync<4>{});
-    testOnDevice<double>(WarpShflDownSync<5>{});
-    testOnDevice<double>(WarpShflDownSync<6>{});
-    testOnDevice<SomeStruct>(WarpShflDownSync<7>{});
-    testOnDevice<SomeStruct>(WarpShflDownSync<8>{});
+    testWarpCollectiveFunction<int>(WarpShflDownSync<1>{});
+    testWarpCollectiveFunction<int>(WarpShflDownSync<2>{});
+    testWarpCollectiveFunction<float>(WarpShflDownSync<3>{});
+    testWarpCollectiveFunction<float>(WarpShflDownSync<4>{});
+    testWarpCollectiveFunction<double>(WarpShflDownSync<5>{});
+    testWarpCollectiveFunction<double>(WarpShflDownSync<6>{});
+    testWarpCollectiveFunction<SomeStruct>(WarpShflDownSync<7>{});
+    testWarpCollectiveFunction<SomeStruct>(WarpShflDownSync<8>{});
 }
 
 struct WarpBallotSync
@@ -282,7 +282,7 @@ struct WarpBallotSync
     };
 };
 
-TEST(WarpScan, ballotSync) { testOnDevice<bool, GpuConfig::ThreadMask>(WarpBallotSync{}); }
+TEST(WarpScan, ballotSync) { testWarpCollectiveFunction<bool, GpuConfig::ThreadMask>(WarpBallotSync{}); }
 
 struct WarpAnySync
 {
@@ -292,7 +292,7 @@ struct WarpAnySync
     { std::ranges::fill(output, std::accumulate(input.begin(), input.end(), false, std::logical_or<bool>{})); };
 };
 
-TEST(WarpScan, anySync) { testOnDevice<bool>(WarpAnySync{}); }
+TEST(WarpScan, anySync) { testWarpCollectiveFunction<bool>(WarpAnySync{}); }
 
 struct WarpMin
 {
@@ -308,9 +308,9 @@ struct WarpMin
 
 TEST(WarpScan, warpMin)
 {
-    testOnDevice<int>(WarpMin{});
-    testOnDevice<float>(WarpMin{});
-    testOnDevice<double>(WarpMin{});
+    testWarpCollectiveFunction<int>(WarpMin{});
+    testWarpCollectiveFunction<float>(WarpMin{});
+    testWarpCollectiveFunction<double>(WarpMin{});
 }
 
 struct WarpMax
@@ -327,9 +327,9 @@ struct WarpMax
 
 TEST(WarpScan, warpMax)
 {
-    testOnDevice<int>(WarpMax{});
-    testOnDevice<float>(WarpMax{});
-    testOnDevice<double>(WarpMax{});
+    testWarpCollectiveFunction<int>(WarpMax{});
+    testWarpCollectiveFunction<float>(WarpMax{});
+    testWarpCollectiveFunction<double>(WarpMax{});
 }
 
 struct WarpBitwiseOr
@@ -346,8 +346,8 @@ struct WarpBitwiseOr
 
 TEST(WarpScan, warpBitwiseOr)
 {
-    testOnDevice<int>(WarpBitwiseOr{});
-    testOnDevice<unsigned>(WarpBitwiseOr{});
+    testWarpCollectiveFunction<int>(WarpBitwiseOr{});
+    testWarpCollectiveFunction<unsigned>(WarpBitwiseOr{});
 }
 
 struct WarpInclusiveScanInt
@@ -358,7 +358,7 @@ struct WarpInclusiveScanInt
     { std::inclusive_scan(input.begin(), input.end(), output.begin()); };
 };
 
-TEST(WarpScan, inclusiveScanInt) { testOnDevice<int>(WarpInclusiveScanInt{}); }
+TEST(WarpScan, inclusiveScanInt) { testWarpCollectiveFunction<int>(WarpInclusiveScanInt{}); }
 
 struct WarpExclusiveScanBool
 {
@@ -368,7 +368,7 @@ struct WarpExclusiveScanBool
     { std::exclusive_scan(input.begin(), input.end(), output.begin(), 0, std::plus<int>()); };
 };
 
-TEST(WarpScan, exclusiveScanBool) { testOnDevice<bool, int>(WarpExclusiveScanBool{}); }
+TEST(WarpScan, exclusiveScanBool) { testWarpCollectiveFunction<bool, int>(WarpExclusiveScanBool{}); }
 
 struct WarpReduceBool
 {
@@ -378,7 +378,7 @@ struct WarpReduceBool
     { std::ranges::fill(output, std::accumulate(input.begin(), input.end(), 0)); };
 };
 
-TEST(WarpScan, reduceBool) { testOnDevice<bool, int>(WarpReduceBool{}); }
+TEST(WarpScan, reduceBool) { testWarpCollectiveFunction<bool, int>(WarpReduceBool{}); }
 
 template<int Carry>
 struct WarpInclusiveSegscanInt
@@ -398,9 +398,9 @@ struct WarpInclusiveSegscanInt
 
 TEST(WarpScan, inclusiveSegscanInt)
 {
-    testOnDevice<int>(WarpInclusiveSegscanInt<1>{});
-    testOnDevice<int>(WarpInclusiveSegscanInt<42>{});
-    testOnDevice<int>(WarpInclusiveSegscanInt<-42>{});
+    testWarpCollectiveFunction<int>(WarpInclusiveSegscanInt<1>{});
+    testWarpCollectiveFunction<int>(WarpInclusiveSegscanInt<42>{});
+    testWarpCollectiveFunction<int>(WarpInclusiveSegscanInt<-42>{});
 }
 
 struct WarpStreamCompact
@@ -423,9 +423,9 @@ struct WarpStreamCompact
 
 TEST(WarpScan, streamCompact)
 {
-    testOnDevice<int>(WarpStreamCompact{});
-    testOnDevice<float>(WarpStreamCompact{});
-    testOnDevice<double>(WarpStreamCompact{});
+    testWarpCollectiveFunction<int>(WarpStreamCompact{});
+    testWarpCollectiveFunction<float>(WarpStreamCompact{});
+    testWarpCollectiveFunction<double>(WarpStreamCompact{});
 }
 
 struct WarpSpreadSeg8
@@ -439,7 +439,7 @@ struct WarpSpreadSeg8
     };
 };
 
-TEST(WarpScan, warpSpreadSeg8) { testOnDevice<int>(WarpSpreadSeg8{}); }
+TEST(WarpScan, warpSpreadSeg8) { testWarpCollectiveFunction<int>(WarpSpreadSeg8{}); }
 
 __global__ void applyAtomicMinFloat(float* addr, float value)
 {

--- a/domain/test/unit_cuda/primitives/warpscan.cu
+++ b/domain/test/unit_cuda/primitives/warpscan.cu
@@ -116,11 +116,10 @@ void verify(thrust::host_vector<InputT> const& input, WarpF warpF, thrust::host_
 {
     ASSERT_EQ(input.size(), output.size());
     ASSERT_EQ(input.size() % GpuConfig::warpSize, 0);
-    for (std::size_t warp = 0; warp < input.size() / GpuConfig::warpSize; ++warp)
+    for (std::size_t i = 0; i < input.size(); i += GpuConfig::warpSize)
     {
-        WarpSpan<const InputT> warpInput(&input[warp * GpuConfig::warpSize], &input[(warp + 1) * GpuConfig::warpSize]);
-        WarpSpan<const OutputT> warpOutput(&output[warp * GpuConfig::warpSize],
-                                           &output[(warp + 1) * GpuConfig::warpSize]);
+        WarpSpan<const InputT> warpInput(&input[i], &input[i + GpuConfig::warpSize]);
+        WarpSpan<const OutputT> warpOutput(&output[i], &output[i + GpuConfig::warpSize]);
         std::array<OutputT, GpuConfig::warpSize> expectedWarpOutput;
 
         warpF(warpInput, WarpSpan<OutputT>(expectedWarpOutput));

--- a/domain/test/unit_cuda/primitives/warpscan.cu
+++ b/domain/test/unit_cuda/primitives/warpscan.cu
@@ -16,11 +16,15 @@
 #include "gtest/gtest.h"
 
 #include <algorithm>
+#include <cstddef>
 #include <functional>
+#include <numeric>
 #include <random>
 #include <ranges>
 #include <span>
+#include <tuple>
 #include <type_traits>
+#include <utility>
 
 #include <thrust/device_vector.h>
 #include <thrust/host_vector.h>

--- a/domain/test/unit_cuda/primitives/warpscan.cu
+++ b/domain/test/unit_cuda/primitives/warpscan.cu
@@ -15,6 +15,12 @@
 
 #include "gtest/gtest.h"
 
+#include <algorithm>
+#include <random>
+#include <ranges>
+#include <span>
+#include <type_traits>
+
 #include <thrust/device_vector.h>
 #include <thrust/host_vector.h>
 
@@ -23,172 +29,188 @@
 
 using namespace cstone;
 
-__global__ void testMin(int* values)
+__device__ unsigned globalIndex()
 {
-    int laneValue = threadIdx.x;
-
-    values[threadIdx.x] = warpMin(laneValue);
+    const auto blockIndex = blockIdx.x + blockIdx.y * gridDim.x + blockIdx.z * gridDim.x * gridDim.y;
+    return blockIndex * blockDim.x * blockDim.y * blockDim.z + threadIdx.x + threadIdx.y * blockDim.x +
+           threadIdx.z * blockDim.x * blockDim.y;
 }
 
-TEST(WarpScan, min)
+template<class InputT, class OutputT = InputT, class F>
+__global__ void applyWarpFunction(InputT* const input, OutputT* output, F f)
 {
-    thrust::host_vector<int> h_v(GpuConfig::warpSize);
-    thrust::device_vector<int> d_v = h_v;
-
-    testMin<<<1, GpuConfig::warpSize>>>(thrust::raw_pointer_cast(d_v.data()));
-
-    h_v = d_v;
-    thrust::host_vector<int> reference(GpuConfig::warpSize, 0);
-
-    EXPECT_EQ(h_v, reference);
+    const unsigned index = globalIndex();
+    output[index]        = f(input[index]);
 }
 
-__global__ void testMax(int* values)
+template<class T>
+std::tuple<dim3, dim3, thrust::host_vector<T>> testData()
 {
-    int laneValue = threadIdx.x;
+    const dim3 numBlocks = {5, 2, 3};
+    const dim3 blockSize = {GpuConfig::warpSize / 4, 2, 6};
 
-    values[threadIdx.x] = warpMax(laneValue);
+    thrust::host_vector<T> data(blockSize.x * blockSize.y * blockSize.z * numBlocks.x * numBlocks.y * numBlocks.z,
+                                T(0));
+    std::fill(data.begin() + GpuConfig::warpSize, data.begin() + GpuConfig::warpSize * 2, T(1));
+
+    using Dist = std::conditional_t<
+        std::is_floating_point_v<T>, std::uniform_real_distribution<T>,
+        std::conditional_t<std::is_same_v<T, bool>, std::bernoulli_distribution, std::uniform_int_distribution<T>>>;
+
+    Dist dist;
+    std::default_random_engine eng;
+    std::generate(data.begin() + GpuConfig::warpSize * 2, data.end(), std::bind(dist, std::ref(eng)));
+
+    return {std::move(numBlocks), std::move(blockSize), std::move(data)};
 }
 
-TEST(WarpScan, max)
+template<class T>
+using WarpSpan = std::span<T, GpuConfig::warpSize>;
+
+template<class InputT, class OutputT, class WarpF>
+thrust::host_vector<OutputT> computeReference(thrust::host_vector<InputT> const& input, WarpF warpF)
 {
-    thrust::host_vector<int> h_v(GpuConfig::warpSize);
-    thrust::device_vector<int> d_v = h_v;
-
-    testMax<<<1, GpuConfig::warpSize>>>(thrust::raw_pointer_cast(d_v.data()));
-
-    h_v = d_v;
-    thrust::host_vector<int> reference(GpuConfig::warpSize, GpuConfig::warpSize - 1);
-
-    EXPECT_EQ(h_v, reference);
-}
-
-__global__ void testScan(int* values)
-{
-    int val             = 1;
-    int scan            = inclusiveScanInt(val);
-    values[threadIdx.x] = scan;
-}
-
-TEST(WarpScan, inclusiveInt)
-{
-    thrust::device_vector<int> d_values(2 * GpuConfig::warpSize);
-    testScan<<<1, 2 * GpuConfig::warpSize>>>(rawPtr(d_values));
-    thrust::host_vector<int> h_values = d_values;
-
-    for (int i = 0; i < 2 * GpuConfig::warpSize; ++i)
+    thrust::host_vector<OutputT> output(input.size());
+    for (std::size_t warp = 0; warp < input.size() / GpuConfig::warpSize; ++warp)
     {
-        EXPECT_EQ(h_values[i], i % GpuConfig::warpSize + 1);
+        WarpSpan<const InputT> warpInput(&input[warp * GpuConfig::warpSize], &input[(warp + 1) * GpuConfig::warpSize]);
+        WarpSpan<OutputT> warpOutput(&output[warp * GpuConfig::warpSize], &output[(warp + 1) * GpuConfig::warpSize]);
+        warpF(warpInput, warpOutput);
     }
+    return output;
 }
 
-__global__ void testScanBool(int* result)
+template<class InputT, class OutputT = InputT, class F>
+void testOnDevice(F f)
 {
-    bool val            = threadIdx.x % 2;
-    result[threadIdx.x] = exclusiveScanBool(val);
+    const auto [numBlocks, blockSize, input] = testData<InputT>();
+
+    thrust::device_vector<InputT> deviceInput = input;
+    thrust::device_vector<OutputT> deviceOutput(input.size());
+    applyWarpFunction<<<numBlocks, blockSize>>>(rawPtr(deviceInput), rawPtr(deviceOutput), f);
+    checkGpuErrors(cudaDeviceSynchronize());
+
+    thrust::host_vector<OutputT> reference = computeReference<InputT, OutputT>(input, F::reference);
+    thrust::host_vector<OutputT> output    = deviceOutput;
+
+    EXPECT_EQ(output, reference);
 }
 
-TEST(WarpScan, bools)
+struct WarpMin
 {
-    thrust::device_vector<int> d_values(2 * GpuConfig::warpSize);
-    testScanBool<<<1, 2 * GpuConfig::warpSize>>>(rawPtr(d_values));
-    thrust::host_vector<int> h_values = d_values;
-
-    for (int i = 0; i < 2 * GpuConfig::warpSize; ++i)
+    template<class T>
+    __device__ T operator()(T x) const
     {
-        EXPECT_EQ(h_values[i], (i % GpuConfig::warpSize) / 2);
+        return warpMin(x);
     }
+
+    static constexpr auto reference = [](auto input, auto output)
+    { std::ranges::fill(output, *std::ranges::min_element(input)); };
+};
+
+TEST(WarpScan, warpMin)
+{
+    testOnDevice<int>(WarpMin{});
+    testOnDevice<float>(WarpMin{});
+    testOnDevice<double>(WarpMin{});
 }
 
-__global__ void testSegScan(int* values)
+struct WarpMax
 {
-    int val = 1;
-
-    if (threadIdx.x == 8) val = 2;
-
-    if (threadIdx.x == 16) val = -2;
-
-    if (threadIdx.x == 31) val = -3;
-
-    int carry           = 1;
-    int scan            = inclusiveSegscanInt(val, carry);
-    values[threadIdx.x] = scan;
-}
-
-TEST(WarpScan, inclusiveSegInt)
-{
-    thrust::device_vector<int> d_values(GpuConfig::warpSize);
-    testSegScan<<<1, GpuConfig::warpSize>>>(rawPtr(d_values));
-    thrust::host_vector<int> h_values = d_values;
-
-    //                         carry is one, first segment starts with offset of 1
-    //                         |                                           | value(16) = -2, scan restarts at 2 - 1
-    std::vector<int> reference{2, 3, 4, 5, 6, 7, 8, 9, 11, 12, 13, 14, 15, 16, 17, 18,
-                               1, 2, 3, 4, 5, 6, 7, 8, 9,  10, 11, 12, 13, 14, 15, 2};
-    //                                                              value(31) = -3, scan restarts at 3 - 1  ^
-
-    // we only check the first 32
-    for (int i = 0; i < 32; ++i)
+    template<class T>
+    __device__ T operator()(T x) const
     {
-        EXPECT_EQ(h_values[i], reference[i]);
+        return warpMax(x);
     }
-}
 
-__global__ void streamCompactTest(int* result)
+    static constexpr auto reference = [](auto input, auto output)
+    { std::ranges::fill(output, *std::ranges::max_element(input)); };
+};
+
+TEST(WarpScan, warpMax)
 {
-    __shared__ int exchange[GpuConfig::warpSize];
-
-    int val     = threadIdx.x;
-    bool keep   = threadIdx.x % 2 == 0;
-    int numKeep = streamCompact(&val, keep, exchange);
-
-    result[threadIdx.x] = val;
+    testOnDevice<int>(WarpMax{});
+    testOnDevice<float>(WarpMax{});
+    testOnDevice<double>(WarpMax{});
 }
+
+struct WarpInclusiveScanInt
+{
+    __device__ int operator()(int x) const { return inclusiveScanInt(x); }
+
+    static constexpr auto reference = [](auto input, auto output)
+    { std::inclusive_scan(input.begin(), input.end(), output.begin()); };
+};
+
+TEST(WarpScan, inclusiveScanInt) { testOnDevice<int>(WarpInclusiveScanInt{}); }
+
+struct WarpExclusiveScanBool
+{
+    __device__ int operator()(bool x) const { return exclusiveScanBool(x); }
+
+    static constexpr auto reference = [](auto input, auto output)
+    { std::exclusive_scan(input.begin(), input.end(), output.begin(), 0, std::plus<int>()); };
+};
+
+TEST(WarpScan, exclusiveScanBool) { testOnDevice<bool, int>(WarpExclusiveScanBool{}); }
+
+template<int Carry>
+struct WarpInclusiveSegscanInt
+{
+    __device__ int operator()(int x) const { return inclusiveSegscanInt(x, Carry); }
+
+    static constexpr auto reference = [](auto input, auto output)
+    {
+        int result = Carry;
+        for (std::size_t i = 0; i < input.size(); ++i)
+        {
+            result    = input[i] < 0 ? -input[i] - 1 : result + input[i];
+            output[i] = result;
+        }
+    };
+};
+
+TEST(WarpScan, inclusiveSegscanInt)
+{
+    testOnDevice<int>(WarpInclusiveSegscanInt<1>{});
+    testOnDevice<int>(WarpInclusiveSegscanInt<42>{});
+    testOnDevice<int>(WarpInclusiveSegscanInt<-42>{});
+}
+
+struct WarpStreamCompact
+{
+    template<class T>
+    __device__ T operator()(T x) const
+    {
+        __shared__ T buffer[GpuConfig::warpSize * 3];
+        T* tmp            = buffer + GpuConfig::warpSize * (threadIdx.z / 2);
+        const int numKeep = streamCompact(&x, x <= 0, tmp);
+        return laneIndex() < numKeep ? x : T(42);
+    }
+
+    static constexpr auto reference = [](auto input, auto output)
+    {
+        auto [_, out] = std::ranges::copy_if(input, output.begin(), [](auto x) { return x <= 0; });
+        std::fill(out, output.end(), 42);
+    };
+};
 
 TEST(WarpScan, streamCompact)
 {
-    thrust::device_vector<int> d_values(GpuConfig::warpSize);
-    streamCompactTest<<<1, GpuConfig::warpSize>>>(rawPtr(d_values));
-    thrust::host_vector<int> h_values = d_values;
-
-    for (int i = 0; i < GpuConfig::warpSize / 2; ++i)
-    {
-        EXPECT_EQ(h_values[i], 2 * i);
-    }
+    testOnDevice<int>(WarpStreamCompact{});
+    testOnDevice<float>(WarpStreamCompact{});
+    testOnDevice<double>(WarpStreamCompact{});
 }
 
-__global__ void spread(int* result)
+struct WarpSpreadSeg8
 {
-    int val = 0;
-    if (threadIdx.x < 4) val = result[threadIdx.x];
+    __device__ int operator()(int x) const { return spreadSeg8(x); }
 
-    result[threadIdx.x] = spreadSeg8(val);
-}
-
-TEST(WarpScan, spreadSeg8)
-{
-    thrust::device_vector<int> d_values(GpuConfig::warpSize);
-
-    d_values[0] = 10;
-    d_values[1] = 20;
-    d_values[2] = 30;
-    d_values[3] = 40;
-
-    spread<<<1, GpuConfig::warpSize>>>(rawPtr(d_values));
-    thrust::host_vector<int> h_values = d_values;
-
-    thrust::host_vector<int> reference =
-        std::vector<int>{10, 11, 12, 13, 14, 15, 16, 17, 20, 21, 22, 23, 24, 25, 26, 27,
-                         30, 31, 32, 33, 34, 35, 36, 37, 40, 41, 42, 43, 44, 45, 46, 47};
-
-    if (GpuConfig::warpSize == 64) // NOLINT
+    static constexpr auto reference = [](auto input, auto output)
     {
-        std::vector<int> tail{0, 1, 2, 3, 4, 5, 6, 7};
-        for (int i = 0; i < 4; ++i)
-        {
-            std::copy(tail.begin(), tail.end(), std::back_inserter(reference));
-        }
-    }
+        for (std::size_t i = 0; i < output.size(); ++i)
+            output[i] = i % 8 == 0 ? input[i / 8] : output[i - 1] + 1;
+    };
+};
 
-    EXPECT_EQ(reference, h_values);
-}
+TEST(WarpScan, warpSpreadSeg8) { testOnDevice<int>(WarpSpreadSeg8{}); }

--- a/domain/test/unit_cuda/primitives/warpscan.cu
+++ b/domain/test/unit_cuda/primitives/warpscan.cu
@@ -139,7 +139,8 @@ void verifyWarpCollectiveFunctionOutput(thrust::host_vector<InputT> const& input
 }
 
 /* Helper to test warp-collective functions on the GPU. InputT/OutputT are per-thread input/output types
- * The functor f provides a reference implementation for a single warp on the host to test against. It must:
+ * The functor f will be invoked on device and must also provide a reference implementation for a single warp on the
+ * host to verify against. I.e., f must:
  * - be a device-callable functor, taking a single argument,
  * - have static member F::reference which is a functor with signature
  *   (WarpSpan<const InputT>, WarpSpan<OutputT>) -> void.

--- a/domain/test/unit_cuda/primitives/warpscan.cu
+++ b/domain/test/unit_cuda/primitives/warpscan.cu
@@ -153,9 +153,10 @@ void testOnDevice(F f)
 
 struct WarpLaneIndex
 {
-    __device__ unsigned operator()(unsigned) const { return laneIndex(); }
+    __device__ unsigned operator()(unsigned /* unused */) const { return laneIndex(); }
 
-    static constexpr auto reference = [](auto input, auto output) { std::iota(output.begin(), output.end(), 0u); };
+    static constexpr auto reference = [](WarpSpan<const unsigned> /* input */, WarpSpan<unsigned> output)
+    { std::iota(output.begin(), output.end(), 0u); };
 };
 
 TEST(WarpScan, laneIndex) { testOnDevice<unsigned>(WarpLaneIndex{}); }
@@ -169,7 +170,8 @@ struct WarpShflSync
         return shflSync(x, Src);
     };
 
-    static constexpr auto reference = [](auto input, auto output) { std::ranges::fill(output, input[Src]); };
+    static constexpr auto reference = []<class T>(WarpSpan<const T> input, WarpSpan<T> output)
+    { std::ranges::fill(output, input[Src]); };
 };
 
 TEST(WarpScan, shflSync)
@@ -193,7 +195,7 @@ struct WarpShflXorSync
         return shflXorSync(x, LaneMask);
     };
 
-    static constexpr auto reference = [](auto input, auto output)
+    static constexpr auto reference = []<class T>(WarpSpan<const T> input, WarpSpan<T> output)
     {
         for (std::size_t i = 0; i < output.size(); ++i)
             output[i] = input[i ^ LaneMask];
@@ -221,7 +223,7 @@ struct WarpShflUpSync
         return shflUpSync(x, Delta);
     };
 
-    static constexpr auto reference = [](auto input, auto output)
+    static constexpr auto reference = []<class T>(WarpSpan<const T> input, WarpSpan<T> output)
     {
         std::copy_n(input.begin(), Delta, output.begin());
         std::copy_n(input.begin(), GpuConfig::warpSize - Delta, output.begin() + Delta);
@@ -249,7 +251,7 @@ struct WarpShflDownSync
         return shflDownSync(x, Delta);
     };
 
-    static constexpr auto reference = [](auto input, auto output)
+    static constexpr auto reference = []<class T>(WarpSpan<const T> input, WarpSpan<T> output)
     {
         std::copy_n(input.begin() + Delta, GpuConfig::warpSize - Delta, output.begin());
         std::copy_n(input.end() - Delta, Delta, output.end() - Delta);
@@ -272,7 +274,7 @@ struct WarpBallotSync
 {
     __device__ GpuConfig::ThreadMask operator()(bool x) const { return ballotSync(x); };
 
-    static constexpr auto reference = [](auto input, auto output)
+    static constexpr auto reference = [](WarpSpan<const bool> input, WarpSpan<GpuConfig::ThreadMask> output)
     {
         GpuConfig::ThreadMask result = 0;
         for (std::size_t i = 0; i < output.size(); ++i)
@@ -287,7 +289,7 @@ struct WarpAnySync
 {
     __device__ bool operator()(bool x) const { return anySync(x); };
 
-    static constexpr auto reference = [](auto input, auto output)
+    static constexpr auto reference = [](WarpSpan<const bool> input, WarpSpan<bool> output)
     { std::ranges::fill(output, std::accumulate(input.begin(), input.end(), false, std::logical_or<bool>{})); };
 };
 
@@ -301,7 +303,7 @@ struct WarpMin
         return warpMin(x);
     }
 
-    static constexpr auto reference = [](auto input, auto output)
+    static constexpr auto reference = []<class T>(WarpSpan<const T> input, WarpSpan<T> output)
     { std::ranges::fill(output, *std::ranges::min_element(input)); };
 };
 
@@ -320,7 +322,7 @@ struct WarpMax
         return warpMax(x);
     }
 
-    static constexpr auto reference = [](auto input, auto output)
+    static constexpr auto reference = []<class T>(WarpSpan<const T> input, WarpSpan<T> output)
     { std::ranges::fill(output, *std::ranges::max_element(input)); };
 };
 
@@ -339,11 +341,8 @@ struct WarpBitwiseOr
         return warpBitwiseOr(x);
     }
 
-    static constexpr auto reference = [](auto input, auto output)
-    {
-        using T = decltype(output)::value_type;
-        std::ranges::fill(output, std::accumulate(input.begin(), input.end(), T(0), std::bit_or<T>{}));
-    };
+    static constexpr auto reference = []<class T>(WarpSpan<const T> input, WarpSpan<T> output)
+    { std::ranges::fill(output, std::accumulate(input.begin(), input.end(), T(0), std::bit_or<T>{})); };
 };
 
 TEST(WarpScan, warpBitwiseOr)
@@ -356,7 +355,7 @@ struct WarpInclusiveScanInt
 {
     __device__ int operator()(int x) const { return inclusiveScanInt(x); }
 
-    static constexpr auto reference = [](auto input, auto output)
+    static constexpr auto reference = [](WarpSpan<const int> input, WarpSpan<int> output)
     { std::inclusive_scan(input.begin(), input.end(), output.begin()); };
 };
 
@@ -366,7 +365,7 @@ struct WarpExclusiveScanBool
 {
     __device__ int operator()(bool x) const { return exclusiveScanBool(x); }
 
-    static constexpr auto reference = [](auto input, auto output)
+    static constexpr auto reference = [](WarpSpan<const bool> input, WarpSpan<int> output)
     { std::exclusive_scan(input.begin(), input.end(), output.begin(), 0, std::plus<int>()); };
 };
 
@@ -376,7 +375,7 @@ struct WarpReduceBool
 {
     __device__ int operator()(bool x) const { return reduceBool(x); }
 
-    static constexpr auto reference = [](auto input, auto output)
+    static constexpr auto reference = [](WarpSpan<const bool> input, WarpSpan<int> output)
     { std::ranges::fill(output, std::accumulate(input.begin(), input.end(), 0)); };
 };
 
@@ -387,7 +386,7 @@ struct WarpInclusiveSegscanInt
 {
     __device__ int operator()(int x) const { return inclusiveSegscanInt(x, Carry); }
 
-    static constexpr auto reference = [](auto input, auto output)
+    static constexpr auto reference = [](WarpSpan<const int> input, WarpSpan<int> output)
     {
         int result = Carry;
         for (std::size_t i = 0; i < input.size(); ++i)
@@ -416,7 +415,7 @@ struct WarpStreamCompact
         return laneIndex() < numKeep ? x : T(42);
     }
 
-    static constexpr auto reference = [](auto input, auto output)
+    static constexpr auto reference = []<class T>(WarpSpan<const T> input, WarpSpan<T> output)
     {
         auto [_, out] = std::ranges::copy_if(input, output.begin(), [](auto x) { return x <= 0; });
         std::fill(out, output.end(), 42);
@@ -434,7 +433,7 @@ struct WarpSpreadSeg8
 {
     __device__ int operator()(int x) const { return spreadSeg8(x); }
 
-    static constexpr auto reference = [](auto input, auto output)
+    static constexpr auto reference = [](WarpSpan<const int> input, WarpSpan<int> output)
     {
         for (std::size_t i = 0; i < output.size(); ++i)
             output[i] = i % 8 == 0 ? input[i / 8] : output[i - 1] + 1;

--- a/domain/test/unit_cuda/primitives/warpscan.cu
+++ b/domain/test/unit_cuda/primitives/warpscan.cu
@@ -11,6 +11,7 @@
  * @brief  Tests for warp-level primitives
  *
  * @author Sebastian Keller <sebastian.f.keller@gmail.com>
+ * @author Felix Thaler <thaler@cscs.ch>
  */
 
 #include "gtest/gtest.h"
@@ -64,7 +65,8 @@ struct SomeStruct
     }
 };
 
-std::ostream& operator<<(std::ostream& out, SomeStruct const& s) {
+std::ostream& operator<<(std::ostream& out, SomeStruct const& s)
+{
     out << "SomeStruct {" << s.a << ", " << s.b << ", " << s.c << ", " << s.d << "}";
     return out;
 }
@@ -116,15 +118,18 @@ void verify(thrust::host_vector<InputT> const& input, WarpF warpF, thrust::host_
     for (std::size_t warp = 0; warp < input.size() / GpuConfig::warpSize; ++warp)
     {
         WarpSpan<const InputT> warpInput(&input[warp * GpuConfig::warpSize], &input[(warp + 1) * GpuConfig::warpSize]);
-        WarpSpan<const OutputT> warpOutput(&output[warp * GpuConfig::warpSize], &output[(warp + 1) * GpuConfig::warpSize]);
+        WarpSpan<const OutputT> warpOutput(&output[warp * GpuConfig::warpSize],
+                                           &output[(warp + 1) * GpuConfig::warpSize]);
         std::array<OutputT, GpuConfig::warpSize> expectedWarpOutput;
 
         warpF(warpInput, WarpSpan<OutputT>(expectedWarpOutput));
 
-        if (!std::ranges::equal(warpOutput, expectedWarpOutput)) {
+        if (!std::ranges::equal(warpOutput, expectedWarpOutput))
+        {
             std::ostringstream failures;
             for (unsigned i = 0; i < GpuConfig::warpSize; ++i)
-                failures << "Lane " << std::setw(2) << i << " - input: " << warpInput[i] << ", output: " << warpOutput[i] << ", expected output: " << expectedWarpOutput[i] << "\n";
+                failures << "Lane " << std::setw(2) << i << " - input: " << warpInput[i]
+                         << ", output: " << warpOutput[i] << ", expected output: " << expectedWarpOutput[i] << "\n";
 
             ADD_FAILURE() << failures.view();
         }


### PR DESCRIPTION
- Introduce `cstone::laneIndex()` which provides the correct lane index on arbitrarily shaped thread blocks.
- Use `cstone::laneIndex()` in all existing warp primitives, to make them work on arbitrarily shaped thread blocks.
- Make `syncWarp` equivalent to cooperative groups API `warp.sync()` on AMD GPUs.
- Support any trivially copyable types in `shfl*Sync` implementations, similar to cooperative groups API `warp.shfl*(...)`.
- Added `anySync` and `warpBitwiseOr`.
- Added unit tests for all functions.