### PR TITLE
Updates for tuple_util: support multiple arguments in for_each_tuple, new tupleMap, removed obsolete zipTuples

### DIFF
--- a/domain/include/cstone/domain/domain.hpp
+++ b/domain/include/cstone/domain/domain.hpp
@@ -427,14 +427,14 @@ private:
         constexpr auto smaller =
             std::make_tuple(util::FindIndex<ConservedVectors&, std::decay_t<decltype(tup)>, SmallerElementSize>{}...);
 
-        auto valueTypeCheck = [](auto index)
+        auto valueTypeCheck = [](auto m, auto s)
         {
             constexpr int numScratchBuffers = std::tuple_size_v<std::decay_t<decltype(tup)>>;
-            static_assert(get<0>(index) < numScratchBuffers || get<1>(index) < numScratchBuffers,
+            static_assert(m < numScratchBuffers || s < numScratchBuffers,
                           "one of the conserved fields has a value_type bigger than the value_types of available "
                           "scratch buffers");
         };
-        util::for_each_tuple(valueTypeCheck, util::zipTuples(matches, smaller));
+        util::for_each_tuple(valueTypeCheck, matches, smaller);
     }
 
     template<class Sorter, class KeyVec, class VectorX, class... Vectors1, class... Vectors2>

--- a/domain/include/cstone/util/tuple_util.hpp
+++ b/domain/include/cstone/util/tuple_util.hpp
@@ -15,7 +15,6 @@
 
 #pragma once
 
-#include <algorithm>
 #include <tuple>
 #include <type_traits>
 #include <utility>
@@ -23,16 +22,61 @@
 namespace util
 {
 
-//! @brief Utility to call function with each element in tuple_
-template<class F, class Tuple>
-void for_each_tuple(F&& func, Tuple&& tuple_)
+namespace detail
 {
-    std::apply([f = func](auto&&... args) { [[maybe_unused]] auto list = std::initializer_list<int>{(f(args), 0)...}; },
-               std::forward<Tuple>(tuple_));
+
+template<std::size_t... Is, class F, class... Tuples>
+inline constexpr auto tupleMapImpl(std::index_sequence<Is...>, F&& f, Tuples&&... tuples)
+{
+    return std::make_tuple(
+        [&f](auto i, auto&&... ts) -> decltype(auto) {
+            return f(std::get<i>(std::forward<decltype(ts)>(ts))...);
+        }(std::integral_constant<std::size_t, Is>(), std::forward<Tuples>(tuples)...)...);
+}
+
+template<std::size_t... Is, class F, class... Tuples>
+inline constexpr auto tupleMapIndexedImpl(std::index_sequence<Is...>, F&& f, Tuples&&... tuples)
+{
+    return std::make_tuple(
+        [&f](auto i, auto&&... ts) -> decltype(auto) {
+            return f(i, std::get<i>(std::forward<decltype(ts)>(ts))...);
+        }(std::integral_constant<std::size_t, Is>(), std::forward<Tuples>(tuples)...)...);
+}
+} // namespace detail
+
+template<class F, class Tuple, class... Tuples>
+inline constexpr auto tupleMap(F&& f, Tuple&& tuple, Tuples&&... tuples)
+{
+    constexpr auto n = std::tuple_size_v<std::decay_t<Tuple>>;
+    static_assert((... && (std::tuple_size_v<std::decay_t<Tuples>> == n)), "All tuples must have same size");
+    return detail::tupleMapImpl(std::make_index_sequence<n>(), std::forward<F>(f), std::forward<Tuple>(tuple),
+                                std::forward<Tuples>(tuples)...);
+}
+
+template<class F, class Tuple, class... Tuples>
+inline constexpr auto tupleMapIndexed(F&& f, Tuple&& tuple, Tuples&&... tuples)
+{
+    constexpr auto n = std::tuple_size_v<std::decay_t<Tuple>>;
+    static_assert((... && (std::tuple_size_v<std::decay_t<Tuples>> == n)), "All tuples must have same size");
+    return detail::tupleMapIndexedImpl(std::make_index_sequence<n>(), std::forward<F>(f), std::forward<Tuple>(tuple),
+                                       std::forward<Tuples>(tuples)...);
+}
+
+//! @brief Utility to call function with each element in tuples
+template<class F, class... Tuples>
+inline constexpr void for_each_tuple(F&& f, Tuples&&... tuples)
+{
+    tupleMap(
+        [&f](auto&&... args)
+        {
+            f(std::forward<decltype(args)>(args)...);
+            return 0;
+        },
+        std::forward<Tuples>(tuples)...);
 }
 
 //! @brief convert an index_sequence into a tuple of integral constants (e.g. for use with for_each_tuple)
-template<size_t... Is>
+template<std::size_t... Is>
 constexpr auto makeIntegralTuple(std::index_sequence<Is...>)
 {
     return std::make_tuple(std::integral_constant<size_t, Is>{}...);
@@ -46,8 +90,8 @@ std::tuple<std::tuple_element_t<Ints, std::decay_t<Tuple>>...> selectTuple(Tuple
 }
 
 template<std::size_t... Is>
-constexpr auto indexSequenceReverse(std::index_sequence<Is...> const&)
-    -> decltype(std::index_sequence<sizeof...(Is) - 1U - Is...>{});
+constexpr auto
+indexSequenceReverse(std::index_sequence<Is...> const&) -> decltype(std::index_sequence<sizeof...(Is) - 1U - Is...>{});
 
 template<std::size_t N>
 using makeIndexSequenceReverse = decltype(indexSequenceReverse(std::make_index_sequence<N>{}));
@@ -64,28 +108,6 @@ template<class Tp>
 constexpr auto discardLastElement(Tp&& tp)
 {
     return selectTuple(std::forward<Tp>(tp), std::make_index_sequence<std::tuple_size_v<std::decay_t<Tp>> - 1>{});
-}
-
-/*! @brief Zip multiple tuples into a single tuple, similar to C++23 std::views::zip, but for tuples (no iterators)
- *
- * @tparam Tps types of tuples
- * @param tps  some tuples, tuple(A0, ..., An), tuple(B0, ..., Bn)
- * @return     a single  tuple( tuple(A0, B0, ...), ...)
- */
-template<class... Tps>
-constexpr auto zipTuples(Tps&&... tps)
-{
-    constexpr std::size_t N = std::min({std::tuple_size_v<std::decay_t<Tps>>...});
-
-    // auto zip = [&tps...]<std::size_t... Is>(std::index_sequence<Is...>) // C++20 (not supported by CUDA 11)
-    auto zip = [&tps...](auto... Is)
-    {
-        auto getIs = [](auto I, Tps&&... tps)
-        { return std::tuple<std::tuple_element_t<I, std::decay_t<Tps>>...>{std::get<I>(std::forward<Tps>(tps))...}; };
-        return std::make_tuple(getIs(std::integral_constant<size_t, Is>{}, std::forward<Tps>(tps)...)...);
-    };
-
-    return std::apply(zip, makeIntegralTuple(std::make_index_sequence<N>{})); // zip(std::make_index_sequence<N>{})
 }
 
 } // namespace util

--- a/domain/include/cstone/util/tuple_util.hpp
+++ b/domain/include/cstone/util/tuple_util.hpp
@@ -28,20 +28,11 @@ namespace detail
 template<std::size_t... Is, class F, class... Tuples>
 inline constexpr auto tupleMapImpl(std::index_sequence<Is...>, F&& f, Tuples&&... tuples)
 {
-    return std::make_tuple(
-        [&f](auto i, auto&&... ts) -> decltype(auto) {
-            return f(std::get<i>(std::forward<decltype(ts)>(ts))...);
-        }(std::integral_constant<std::size_t, Is>(), std::forward<Tuples>(tuples)...)...);
+    return std::make_tuple([&f](auto i, auto&&... ts) -> decltype(auto)
+                           { return f(std::get<i>(std::forward<decltype(ts)>(ts))...); }(
+                               std::integral_constant<std::size_t, Is>(), std::forward<Tuples>(tuples)...)...);
 }
 
-template<std::size_t... Is, class F, class... Tuples>
-inline constexpr auto tupleMapIndexedImpl(std::index_sequence<Is...>, F&& f, Tuples&&... tuples)
-{
-    return std::make_tuple(
-        [&f](auto i, auto&&... ts) -> decltype(auto) {
-            return f(i, std::get<i>(std::forward<decltype(ts)>(ts))...);
-        }(std::integral_constant<std::size_t, Is>(), std::forward<Tuples>(tuples)...)...);
-}
 } // namespace detail
 
 template<class F, class Tuple, class... Tuples>
@@ -51,15 +42,6 @@ inline constexpr auto tupleMap(F&& f, Tuple&& tuple, Tuples&&... tuples)
     static_assert((... && (std::tuple_size_v<std::decay_t<Tuples>> == n)), "All tuples must have same size");
     return detail::tupleMapImpl(std::make_index_sequence<n>(), std::forward<F>(f), std::forward<Tuple>(tuple),
                                 std::forward<Tuples>(tuples)...);
-}
-
-template<class F, class Tuple, class... Tuples>
-inline constexpr auto tupleMapIndexed(F&& f, Tuple&& tuple, Tuples&&... tuples)
-{
-    constexpr auto n = std::tuple_size_v<std::decay_t<Tuple>>;
-    static_assert((... && (std::tuple_size_v<std::decay_t<Tuples>> == n)), "All tuples must have same size");
-    return detail::tupleMapIndexedImpl(std::make_index_sequence<n>(), std::forward<F>(f), std::forward<Tuple>(tuple),
-                                       std::forward<Tuples>(tuples)...);
 }
 
 //! @brief Utility to call function with each element in tuples
@@ -90,8 +72,8 @@ std::tuple<std::tuple_element_t<Ints, std::decay_t<Tuple>>...> selectTuple(Tuple
 }
 
 template<std::size_t... Is>
-constexpr auto
-indexSequenceReverse(std::index_sequence<Is...> const&) -> decltype(std::index_sequence<sizeof...(Is) - 1U - Is...>{});
+constexpr auto indexSequenceReverse(std::index_sequence<Is...> const&)
+    -> decltype(std::index_sequence<sizeof...(Is) - 1U - Is...>{});
 
 template<std::size_t N>
 using makeIndexSequenceReverse = decltype(indexSequenceReverse(std::make_index_sequence<N>{}));

--- a/domain/include/cstone/util/tuple_util.hpp
+++ b/domain/include/cstone/util/tuple_util.hpp
@@ -22,32 +22,26 @@
 namespace util
 {
 
-namespace detail
-{
-
-template<std::size_t... Is, class F, class... Tuples>
-inline constexpr auto tupleMapImpl(std::index_sequence<Is...>, F&& f, Tuples&&... tuples)
-{
-    return std::make_tuple(
-        [&f](auto i, auto&&... ts) -> decltype(auto) {
-            return f(std::get<i>(std::forward<decltype(ts)>(ts))...);
-        }(std::integral_constant<std::size_t, Is>(), std::forward<Tuples>(tuples)...)...);
-}
-
-} // namespace detail
-
-template<class F, class Tuple, class... Tuples>
-inline constexpr auto tupleMap(F&& f, Tuple&& tuple, Tuples&&... tuples)
-{
-    constexpr auto n = std::tuple_size_v<std::decay_t<Tuple>>;
-    static_assert((... && (std::tuple_size_v<std::decay_t<Tuples>> == n)), "All tuples must have same size");
-    return detail::tupleMapImpl(std::make_index_sequence<n>(), std::forward<F>(f), std::forward<Tuple>(tuple),
-                                std::forward<Tuples>(tuples)...);
-}
-
-//! @brief Utility to call function with each element in tuples
+//! @brief Calls function @p f(get<Is>(tuples...)... and return results in a new tuple
 template<class F, class... Tuples>
-inline constexpr void for_each_tuple(F&& f, Tuples&&... tuples)
+constexpr auto tupleMap(F&& f, Tuples&&... tuples)
+{
+    constexpr auto n = std::min({std::tuple_size_v<std::decay_t<Tuples>>...});
+    static_assert(n == std::max({std::tuple_size_v<std::decay_t<Tuples>>...}), "All tuples must have same size");
+
+    auto impl = [&f]<std::size_t... Is>(std::index_sequence<Is...>, auto&&... ts)
+    {
+        return std::make_tuple(
+            [&f](auto i, auto&&... ts_) -> decltype(auto) {
+                return f(std::get<i>(std::forward<decltype(ts_)>(ts_))...);
+            }(std::integral_constant<std::size_t, Is>{}, std::forward<Tuples>(ts)...)...);
+    };
+    return impl(std::make_index_sequence<n>{}, std::forward<Tuples>(tuples)...);
+}
+
+//! @brief Calls void returning function @p f(get<Is>(tuples...)...
+template<class F, class... Tuples>
+constexpr void for_each_tuple(F&& f, Tuples&&... tuples)
 {
     tupleMap(
         [&f](auto&&... args)

--- a/domain/include/cstone/util/tuple_util.hpp
+++ b/domain/include/cstone/util/tuple_util.hpp
@@ -28,9 +28,10 @@ namespace detail
 template<std::size_t... Is, class F, class... Tuples>
 inline constexpr auto tupleMapImpl(std::index_sequence<Is...>, F&& f, Tuples&&... tuples)
 {
-    return std::make_tuple([&f](auto i, auto&&... ts) -> decltype(auto)
-                           { return f(std::get<i>(std::forward<decltype(ts)>(ts))...); }(
-                               std::integral_constant<std::size_t, Is>(), std::forward<Tuples>(tuples)...)...);
+    return std::make_tuple(
+        [&f](auto i, auto&&... ts) -> decltype(auto) {
+            return f(std::get<i>(std::forward<decltype(ts)>(ts))...);
+        }(std::integral_constant<std::size_t, Is>(), std::forward<Tuples>(tuples)...)...);
 }
 
 } // namespace detail
@@ -72,8 +73,8 @@ std::tuple<std::tuple_element_t<Ints, std::decay_t<Tuple>>...> selectTuple(Tuple
 }
 
 template<std::size_t... Is>
-constexpr auto indexSequenceReverse(std::index_sequence<Is...> const&)
-    -> decltype(std::index_sequence<sizeof...(Is) - 1U - Is...>{});
+constexpr auto
+indexSequenceReverse(std::index_sequence<Is...> const&) -> decltype(std::index_sequence<sizeof...(Is) - 1U - Is...>{});
 
 template<std::size_t N>
 using makeIndexSequenceReverse = decltype(indexSequenceReverse(std::make_index_sequence<N>{}));


### PR DESCRIPTION
- Support multiple arguments in `for_each_tuple`, making `zipTuples` obsolete.
- Added `tupleMap`, which applies the given function to each element and returns a new tuple of the resulting values.
- Removed `zipTuples`.