### PR TITLE
Fix Compiler Warnings and Related Issues

### DIFF
--- a/domain/include/cstone/cuda/errorcheck.cuh
+++ b/domain/include/cstone/cuda/errorcheck.cuh
@@ -26,7 +26,7 @@ inline void checkErr(cudaError_t err, const char* filename, int lineno, const ch
 
 #define checkGpuErrors(errcode) checkErr((errcode), __FILE__, __LINE__, #errcode)
 
-static void kernelSuccess(const char kernel[] = "kernel")
+inline void kernelSuccess(const char kernel[] = "kernel")
 {
     cudaError_t err = cudaDeviceSynchronize();
     if (err != cudaSuccess)

--- a/domain/include/cstone/domain/domain.hpp
+++ b/domain/include/cstone/domain/domain.hpp
@@ -239,8 +239,8 @@ public:
         if (firstCall_)
         {
             // first rough convergence to avoid computing expansion centers of large nodes with a lot of particles
-            focusTree_.converge(box(), keyView, global_.assignment(), global_.treeLeaves(), global_.nodeCounts(),
-                                1.0, std::get<0>(scratch));
+            focusTree_.converge(box(), keyView, global_.assignment(), global_.treeLeaves(), global_.nodeCounts(), 1.0,
+                                std::get<0>(scratch));
             focusTree_.updateMinMac(global_.assignment(), 1.0, false);
             int converged = 0, reps = 0;
             while (converged != numRanks_ || reps < 2)
@@ -248,7 +248,8 @@ public:
                 converged =
                     focusTree_.updateTree(global_.assignment(), global_.treeLeaves(), box(), std::get<0>(scratch));
                 focusTree_.updateCounts(keyView, global_.treeLeaves(), global_.nodeCounts(), std::get<0>(scratch));
-                focusTree_.updateCenters(rawPtr(x), rawPtr(y), rawPtr(z), rawPtr(m), global_.octree(), std::get<0>(scratch));
+                focusTree_.updateCenters(rawPtr(x), rawPtr(y), rawPtr(z), rawPtr(m), global_.octree(),
+                                         std::get<0>(scratch));
                 focusTree_.updateMacs(global_.assignment(), 1.0 / theta_, false);
                 MPI_Allreduce(MPI_IN_PLACE, &converged, 1, MPI_INT, MPI_SUM, comm_);
                 reps++;
@@ -261,7 +262,8 @@ public:
             focusTree_.updateMacs(global_.assignment(), centerDriftTol_ / theta_, true);
             focusTree_.updateTree(global_.assignment(), global_.treeLeaves(), box(), std::get<0>(scratch));
             focusTree_.updateCounts(keyView, global_.treeLeaves(), global_.nodeCounts(), std::get<0>(scratch));
-            focusTree_.updateCenters(rawPtr(x), rawPtr(y), rawPtr(z), rawPtr(m), global_.octree(), std::get<0>(scratch));
+            focusTree_.updateCenters(rawPtr(x), rawPtr(y), rawPtr(z), rawPtr(m), global_.octree(),
+                                     std::get<0>(scratch));
             focusTree_.updateMacs(global_.assignment(), 1.0 / theta_, false);
 
             reallocate(focusTree_.octreeViewAcc().numLeafNodes + 1, allocGrowthRate_, layout_, layoutAcc_);

--- a/domain/include/cstone/domain/domain.hpp
+++ b/domain/include/cstone/domain/domain.hpp
@@ -248,8 +248,7 @@ public:
                 converged =
                     focusTree_.updateTree(global_.assignment(), global_.treeLeaves(), box(), std::get<0>(scratch));
                 focusTree_.updateCounts(keyView, global_.treeLeaves(), global_.nodeCounts(), std::get<0>(scratch));
-                focusTree_.updateCenters(rawPtr(x), rawPtr(y), rawPtr(z), rawPtr(m), global_.octree(),
-                                         std::get<0>(scratch), std::get<1>(scratch));
+                focusTree_.updateCenters(rawPtr(x), rawPtr(y), rawPtr(z), rawPtr(m), global_.octree(), std::get<0>(scratch));
                 focusTree_.updateMacs(global_.assignment(), 1.0 / theta_, false);
                 MPI_Allreduce(MPI_IN_PLACE, &converged, 1, MPI_INT, MPI_SUM, comm_);
                 reps++;
@@ -262,8 +261,7 @@ public:
             focusTree_.updateMacs(global_.assignment(), centerDriftTol_ / theta_, true);
             focusTree_.updateTree(global_.assignment(), global_.treeLeaves(), box(), std::get<0>(scratch));
             focusTree_.updateCounts(keyView, global_.treeLeaves(), global_.nodeCounts(), std::get<0>(scratch));
-            focusTree_.updateCenters(rawPtr(x), rawPtr(y), rawPtr(z), rawPtr(m), global_.octree(), std::get<0>(scratch),
-                                     std::get<1>(scratch));
+            focusTree_.updateCenters(rawPtr(x), rawPtr(y), rawPtr(z), rawPtr(m), global_.octree(), std::get<0>(scratch));
             focusTree_.updateMacs(global_.assignment(), 1.0 / theta_, false);
 
             reallocate(focusTree_.octreeViewAcc().numLeafNodes + 1, allocGrowthRate_, layout_, layoutAcc_);
@@ -363,12 +361,11 @@ public:
     void setGrowthAllocRate(float factor) { allocGrowthRate_ = factor; }
 
     //! @brief update expansion (c.o.m) centers of the focus tree
-    template<class VectorX, class VectorM, class VectorS1, class VectorS2>
-    void updateExpansionCenters(VectorX& x, VectorX& y, VectorX& z, VectorM& m, VectorS1& s1, VectorS2& s2)
+    template<class VectorX, class VectorM, class VectorS1>
+    void updateExpansionCenters(VectorX& x, VectorX& y, VectorX& z, VectorM& m, VectorS1& s1)
     {
         auto si = startIndex();
-        focusTree_.updateCenters(rawPtr(x) + si, rawPtr(y) + si, rawPtr(z) + si, rawPtr(m) + si, global_.octree(), s1,
-                                 s2);
+        focusTree_.updateCenters(rawPtr(x) + si, rawPtr(y) + si, rawPtr(z) + si, rawPtr(m) + si, global_.octree(), s1);
         focusTree_.setMacRadius(1.0 / theta_);
     };
 

--- a/domain/include/cstone/domain/domaindecomp_mpi.hpp
+++ b/domain/include/cstone/domain/domaindecomp_mpi.hpp
@@ -139,10 +139,7 @@ void exchangeParticles(int epoch,
         receiveStart += receiveCount;
     }
 
-    if (not sendRequests.empty())
-    {
-        MPI_Waitall(int(sendRequests.size()), sendRequests.data(), MPI_STATUSES_IGNORE);
-    }
+    if (not sendRequests.empty()) { MPI_Waitall(int(sendRequests.size()), sendRequests.data(), MPI_STATUSES_IGNORE); }
 
     // If this process is going to send messages with rank/tag combinations
     // already sent in this function, this can lead to messages being mixed up

--- a/domain/include/cstone/domain/domaindecomp_mpi.hpp
+++ b/domain/include/cstone/domain/domaindecomp_mpi.hpp
@@ -141,8 +141,7 @@ void exchangeParticles(int epoch,
 
     if (not sendRequests.empty())
     {
-        MPI_Status status[sendRequests.size()];
-        MPI_Waitall(int(sendRequests.size()), sendRequests.data(), status);
+        MPI_Waitall(int(sendRequests.size()), sendRequests.data(), MPI_STATUSES_IGNORE);
     }
 
     // If this process is going to send messages with rank/tag combinations

--- a/domain/include/cstone/domain/domaindecomp_mpi_gpu.cuh
+++ b/domain/include/cstone/domain/domaindecomp_mpi_gpu.cuh
@@ -146,8 +146,7 @@ void exchangeParticlesGpu(int epoch,
 
     if (not sendRequests.empty())
     {
-        MPI_Status status[sendRequests.size()];
-        MPI_Waitall(int(sendRequests.size()), sendRequests.data(), status);
+        MPI_Waitall(int(sendRequests.size()), sendRequests.data(), MPI_STATUSES_IGNORE);
     }
 
     reallocate(sendScratchBuffer, oldSendSize, 1.01);

--- a/domain/include/cstone/domain/domaindecomp_mpi_gpu.cuh
+++ b/domain/include/cstone/domain/domaindecomp_mpi_gpu.cuh
@@ -144,10 +144,7 @@ void exchangeParticlesGpu(int epoch,
         receiveStart += receiveCount;
     }
 
-    if (not sendRequests.empty())
-    {
-        MPI_Waitall(int(sendRequests.size()), sendRequests.data(), MPI_STATUSES_IGNORE);
-    }
+    if (not sendRequests.empty()) { MPI_Waitall(int(sendRequests.size()), sendRequests.data(), MPI_STATUSES_IGNORE); }
 
     reallocate(sendScratchBuffer, oldSendSize, 1.01);
     reallocate(recvScratchBuffer, oldRecvSize, 1.01);

--- a/domain/include/cstone/domain/exchange_keys.hpp
+++ b/domain/include/cstone/domain/exchange_keys.hpp
@@ -89,8 +89,7 @@ SendList exchangeRequestKeys(std::span<const KeyType> treeLeaves,
         }
     }
 
-    MPI_Status status[sendRequests.size()];
-    MPI_Waitall(int(sendRequests.size()), sendRequests.data(), status);
+    MPI_Waitall(int(sendRequests.size()), sendRequests.data(), MPI_STATUSES_IGNORE);
 
     // MUST call MPI_Barrier or any other collective MPI operation that enforces synchronization
     // across all ranks before calling this function again

--- a/domain/include/cstone/focus/exchange_focus.hpp
+++ b/domain/include/cstone/focus/exchange_focus.hpp
@@ -238,7 +238,7 @@ void syncTreeletsGpu(std::span<const int> exteriorPeers,
     exchangeRejectedKeys<KeyType>(interiorPeers, exteriorPeers, leaves, treelets, nodeOps, comm);
     pruneTreelets<KeyType>(interiorPeers, treelets);
 
-    if (std::count(nodeOps.begin(), nodeOps.end(), 1) != nodeOps.size())
+    if (std::count(nodeOps.begin(), nodeOps.end(), 1) != long(nodeOps.size()))
     {
         assert(octreeAcc.childOffsets.size() >= nodeOps.size());
         std::span<TreeNodeIndex> nops(rawPtr(octreeAcc.childOffsets), nodeOps.size());

--- a/domain/include/cstone/focus/octree_focus.hpp
+++ b/domain/include/cstone/focus/octree_focus.hpp
@@ -169,7 +169,8 @@ struct CombinedUpdate
 
         if (status == ResolutionStatus::cancelMerge)
         {
-            converged = countGpu(nodeOps.data(), nodeOps.data() + nodeOps.size() - 1, 1) == std::size_t(tree.numLeafNodes);
+            converged =
+                countGpu(nodeOps.data(), nodeOps.data() + nodeOps.size() - 1, 1) == std::size_t(tree.numLeafNodes);
         }
         else if (status == ResolutionStatus::rebalance) { converged = false; }
 

--- a/domain/include/cstone/focus/octree_focus.hpp
+++ b/domain/include/cstone/focus/octree_focus.hpp
@@ -169,7 +169,7 @@ struct CombinedUpdate
 
         if (status == ResolutionStatus::cancelMerge)
         {
-            converged = countGpu(nodeOps.data(), nodeOps.data() + nodeOps.size() - 1, 1) == tree.numLeafNodes;
+            converged = countGpu(nodeOps.data(), nodeOps.data() + nodeOps.size() - 1, 1) == std::size_t(tree.numLeafNodes);
         }
         else if (status == ResolutionStatus::rebalance) { converged = false; }
 

--- a/domain/include/cstone/focus/octree_focus_mpi.hpp
+++ b/domain/include/cstone/focus/octree_focus_mpi.hpp
@@ -355,8 +355,7 @@ public:
                        const RealType* z,
                        const Tm* m,
                        OctreeView<const KeyType> gOctree,
-                       DevVec1&& scratch1 = std::vector<LocalIndex>{},
-                       DevVec2&& scratch2 = std::vector<LocalIndex>{})
+                       DevVec1&& scratch1 = std::vector<LocalIndex>{})
     {
         assert(gOctree.leaves != nullptr);
         TreeNodeIndex firstIdx           = assignment_[myRank_].start();
@@ -377,7 +376,7 @@ public:
 
         if constexpr (HaveGpu<Accelerator>{})
         {
-            static_assert(IsDeviceVector<std::decay_t<DevVec1>>{} && IsDeviceVector<std::decay_t<DevVec2>>{});
+            static_assert(IsDeviceVector<std::decay_t<DevVec1>>{});
             size_t bytesLayout = (octree.numLeafNodes + 1) * sizeof(LocalIndex);
             size_t osz1        = reallocateBytes(scratch1, bytesLayout, allocGrowthRate_);
             auto* d_layout     = reinterpret_cast<LocalIndex*>(rawPtr(scratch1));

--- a/domain/include/cstone/focus/octree_focus_mpi.hpp
+++ b/domain/include/cstone/focus/octree_focus_mpi.hpp
@@ -332,7 +332,7 @@ public:
         {
             gather<TreeNodeIndex>(idxFromGlob, toInternal, idxFromGlob.data());
 #pragma omp parallel for schedule(static)
-            for (TreeNodeIndex i = 0; i < idxFromGlob.size(); ++i)
+            for (std::size_t i = 0; i < idxFromGlob.size(); ++i)
             {
                 letToGlob[i] = locateNode(octreeAcc_.prefixes[idxFromGlob[i]], globalNodeKeys, globalLevelRange);
             }

--- a/domain/include/cstone/halos/exchange_halos.hpp
+++ b/domain/include/cstone/halos/exchange_halos.hpp
@@ -84,8 +84,7 @@ void haloexchange(int epoch, const RecvList& incomingHalos, const SendList& outg
 
     if (not sendRequests.empty())
     {
-        MPI_Status status[sendRequests.size()];
-        MPI_Waitall(int(sendRequests.size()), sendRequests.data(), status);
+        MPI_Waitall(int(sendRequests.size()), sendRequests.data(), MPI_STATUSES_IGNORE);
     }
 
     // MUST call MPI_Barrier or any other collective MPI operation that enforces synchronization

--- a/domain/include/cstone/halos/exchange_halos.hpp
+++ b/domain/include/cstone/halos/exchange_halos.hpp
@@ -24,8 +24,8 @@ namespace cstone
 {
 
 template<class... Arrays>
-void haloexchange(int epoch, const RecvList& incomingHalos, const SendList& outgoingHalos, MPI_Comm comm,
-                  Arrays... arrays)
+void haloexchange(
+    int epoch, const RecvList& incomingHalos, const SendList& outgoingHalos, MPI_Comm comm, Arrays... arrays)
 {
     using TransferType      = uint64_t;
     constexpr int alignment = sizeof(TransferType);
@@ -82,10 +82,7 @@ void haloexchange(int epoch, const RecvList& incomingHalos, const SendList& outg
         for_each_tuple(unpack, packTuple);
     }
 
-    if (not sendRequests.empty())
-    {
-        MPI_Waitall(int(sendRequests.size()), sendRequests.data(), MPI_STATUSES_IGNORE);
-    }
+    if (not sendRequests.empty()) { MPI_Waitall(int(sendRequests.size()), sendRequests.data(), MPI_STATUSES_IGNORE); }
 
     // MUST call MPI_Barrier or any other collective MPI operation that enforces synchronization
     // across all ranks before calling this function again.

--- a/domain/include/cstone/halos/exchange_halos_gpu.cuh
+++ b/domain/include/cstone/halos/exchange_halos_gpu.cuh
@@ -108,10 +108,7 @@ void haloExchangeGpu(int epoch,
         checkGpuErrors(cudaDeviceSynchronize());
     }
 
-    if (not sendRequests.empty())
-    {
-        MPI_Waitall(int(sendRequests.size()), sendRequests.data(), MPI_STATUSES_IGNORE);
-    }
+    if (not sendRequests.empty()) { MPI_Waitall(int(sendRequests.size()), sendRequests.data(), MPI_STATUSES_IGNORE); }
 
     checkGpuErrors(cudaFree(d_range));
     reallocate(sendScratchBuffer, oldSendSize, 1.0);

--- a/domain/include/cstone/halos/exchange_halos_gpu.cuh
+++ b/domain/include/cstone/halos/exchange_halos_gpu.cuh
@@ -110,8 +110,7 @@ void haloExchangeGpu(int epoch,
 
     if (not sendRequests.empty())
     {
-        MPI_Status status[sendRequests.size()];
-        MPI_Waitall(int(sendRequests.size()), sendRequests.data(), status);
+        MPI_Waitall(int(sendRequests.size()), sendRequests.data(), MPI_STATUSES_IGNORE);
     }
 
     checkGpuErrors(cudaFree(d_range));

--- a/domain/include/cstone/tree/continuum.hpp
+++ b/domain/include/cstone/tree/continuum.hpp
@@ -48,7 +48,7 @@ template<class KeyType, class T, class F>
 void computeContinuumCounts(
     const KeyType* tree, unsigned* counts, TreeNodeIndex numNodes, const Box<T>& box, F&& concentration)
 {
-#pragma ompe parallel for schedule(static)
+#pragma omp parallel for schedule(static)
     for (TreeNodeIndex i = 0; i < numNodes; ++i)
     {
         counts[i] = continuumCount(tree[i], tree[i + 1], box, concentration);

--- a/domain/test/integration_mpi/domain_gpu.cpp
+++ b/domain/test/integration_mpi/domain_gpu.cpp
@@ -231,7 +231,7 @@ TEST(DomainGpu, reapplySync)
     std::vector<Real> dl_property = toHost(property);
 
     int numPass = 0;
-    for (int i = domain.startIndex(); i < domain.endIndex(); ++i)
+    for (auto i = domain.startIndex(); i < domain.endIndex(); ++i)
     {
         if (dl_property[i] == host_property[i]) numPass++;
     }
@@ -340,7 +340,7 @@ void randomGaussianGrav(int thisRank, int numRanks)
     }
 
     EXPECT_EQ(layout, h_layout);
-    for (TreeNodeIndex i = 0; i < centers.size(); ++i)
+    for (std::size_t i = 0; i < centers.size(); ++i)
     {
         EXPECT_NEAR(norm2(centers[i] - h_centers[i]), 0.0, 1e-6);
     }

--- a/domain/test/integration_mpi/domain_gpu.cpp
+++ b/domain/test/integration_mpi/domain_gpu.cpp
@@ -278,10 +278,10 @@ TEST(DomainGpu, Allgatherv)
 template<class KeyType, class T>
 void randomGaussianGrav(int thisRank, int numRanks)
 {
-    const LocalIndex numParticles    = 100000;
-    unsigned         bucketSize      = numParticles / (100 * numRanks);
-    unsigned         bucketSizeLocal = std::min(64u, bucketSize);
-    float            theta           = 0.5;
+    const LocalIndex numParticles = 100000;
+    unsigned bucketSize           = numParticles / (100 * numRanks);
+    unsigned bucketSizeLocal      = std::min(64u, bucketSize);
+    float theta                   = 0.5;
 
     Box<T> box{-1, 1};
 
@@ -296,11 +296,11 @@ void randomGaussianGrav(int thisRank, int numRanks)
 
     // extract a slice of the common pool, each rank takes a different slice, but all slices together
     // are equal to the common pool
-    std::vector<T>       x(coords.x().begin() + firstIndex, coords.x().begin() + lastIndex);
-    std::vector<T>       y(coords.y().begin() + firstIndex, coords.y().begin() + lastIndex);
-    std::vector<T>       z(coords.z().begin() + firstIndex, coords.z().begin() + lastIndex);
-    std::vector<T>       h(coords.h().begin() + firstIndex, coords.h().begin() + lastIndex);
-    std::vector<T>       m(globalMasses.begin() + firstIndex, globalMasses.begin() + lastIndex);
+    std::vector<T> x(coords.x().begin() + firstIndex, coords.x().begin() + lastIndex);
+    std::vector<T> y(coords.y().begin() + firstIndex, coords.y().begin() + lastIndex);
+    std::vector<T> z(coords.z().begin() + firstIndex, coords.z().begin() + lastIndex);
+    std::vector<T> h(coords.h().begin() + firstIndex, coords.h().begin() + lastIndex);
+    std::vector<T> m(globalMasses.begin() + firstIndex, globalMasses.begin() + lastIndex);
     std::vector<KeyType> keys(x.size());
 
     DeviceVector<T> d_x          = x;
@@ -329,7 +329,8 @@ void randomGaussianGrav(int thisRank, int numRanks)
                                                    domain.focusTree().expansionCentersAcc().end());
     }
     {
-        Domain<KeyType, T, GpuTag> domainGpu(thisRank, numRanks, bucketSize, bucketSizeLocal, theta, MPI_COMM_WORLD, box);
+        Domain<KeyType, T, GpuTag> domainGpu(thisRank, numRanks, bucketSize, bucketSizeLocal, theta, MPI_COMM_WORLD,
+                                             box);
         DeviceVector<T> ds1, ds2, gpuOrdering;
         domainGpu.syncGrav(d_keys, d_x, d_y, d_z, d_h, d_m, std::tuple{}, std::tie(ds1, ds2, gpuOrdering));
         domainGpu.exchangeHalos(std::tie(d_m), ds1, ds2);

--- a/domain/test/integration_mpi/domain_nranks.cpp
+++ b/domain/test/integration_mpi/domain_nranks.cpp
@@ -34,7 +34,7 @@
 using namespace cstone;
 
 template<class KeyType, class T, class DomainType>
-void randomGaussianDomain(DomainType domain, int rank, int nRanks, bool equalizeH = false)
+void randomGaussianDomain(DomainType domain, int rank, int nRanks)
 {
     LocalIndex numParticles = (1000 / nRanks) * nRanks;
     Box<T> box              = domain.box();

--- a/domain/test/integration_mpi/domain_nranks.cpp
+++ b/domain/test/integration_mpi/domain_nranks.cpp
@@ -310,7 +310,7 @@ TEST(FocusDomain, reapplySync)
     EXPECT_EQ(property.size(), propertyCpy.size());
 
     int numPass = 0;
-    for (int i = domain.startIndex(); i < domain.endIndex(); ++i)
+    for (auto i = domain.startIndex(); i < domain.endIndex(); ++i)
     {
         if (property[i] == propertyCpy[i]) numPass++;
     }
@@ -379,7 +379,7 @@ void randomGaussianGrav(int thisRank, int numRanks)
     // Any leaf in the tree with particles: does it contain the same particles as in the reference set of particles?
 
     ASSERT_EQ(let_leaves.size(), let_layout.size());
-    for (int i = 0; i < let_leaves.size() - 1; ++i)
+    for (std::size_t i = 0; i < let_leaves.size() - 1; ++i)
     {
         if (let_layout[i + 1] > let_layout[i])
         {
@@ -391,7 +391,7 @@ void randomGaussianGrav(int thisRank, int numRanks)
             int gi2 = std::lower_bound(gkeys.begin(), gkeys.end(), pk2) - gkeys.begin();
             EXPECT_EQ(gi2 - gi1 + 1, let_lcounts[i]);
 
-            for (int d = 0; d < let_lcounts[i]; ++d)
+            for (LocalIndex d = 0; d < let_lcounts[i]; ++d)
             {
                 EXPECT_EQ(keys[let_layout[i] + d], gkeys[gi1 + d]);
             }
@@ -422,7 +422,7 @@ void randomGaussianGrav(int thisRank, int numRanks)
         spanningKeys.back() = focusEnd;
 
         std::vector<uint8_t> marks(let_full.numNodes, 0);
-        for (TreeNodeIndex i = 0; i < nNodes(spanningKeys); ++i)
+        for (std::size_t i = 0; i < nNodes(spanningKeys); ++i)
         {
             IBox target                     = sfcIBox(sfcKey(spanningKeys[i]), sfcKey(spanningKeys[i + 1]));
             auto [targetCenter, targetSize] = centerAndSize<KeyType>(target, box);

--- a/domain/test/integration_mpi/domain_nranks.cpp
+++ b/domain/test/integration_mpi/domain_nranks.cpp
@@ -135,19 +135,23 @@ TEST(FocusDomain, randomGaussianNeighborSumPbc)
 
     auto periodic = BoundaryType::periodic;
     {
-        Domain<unsigned, double> domain(rank, nRanks, bucketSize, bucketSizeFocus, theta, MPI_COMM_WORLD, {-1, 1, periodic});
+        Domain<unsigned, double> domain(rank, nRanks, bucketSize, bucketSizeFocus, theta, MPI_COMM_WORLD,
+                                        {-1, 1, periodic});
         randomGaussianDomain<unsigned, double>(domain, rank, nRanks);
     }
     {
-        Domain<uint64_t, double> domain(rank, nRanks, bucketSize, bucketSizeFocus, theta, MPI_COMM_WORLD, {-1, 1, periodic});
+        Domain<uint64_t, double> domain(rank, nRanks, bucketSize, bucketSizeFocus, theta, MPI_COMM_WORLD,
+                                        {-1, 1, periodic});
         randomGaussianDomain<uint64_t, double>(domain, rank, nRanks);
     }
     {
-        Domain<unsigned, float> domain(rank, nRanks, bucketSize, bucketSizeFocus, theta, MPI_COMM_WORLD, {-1, 1, periodic});
+        Domain<unsigned, float> domain(rank, nRanks, bucketSize, bucketSizeFocus, theta, MPI_COMM_WORLD,
+                                       {-1, 1, periodic});
         randomGaussianDomain<unsigned, float>(domain, rank, nRanks);
     }
     {
-        Domain<uint64_t, float> domain(rank, nRanks, bucketSize, bucketSizeFocus, theta, MPI_COMM_WORLD, {-1, 1, periodic});
+        Domain<uint64_t, float> domain(rank, nRanks, bucketSize, bucketSizeFocus, theta, MPI_COMM_WORLD,
+                                       {-1, 1, periodic});
         randomGaussianDomain<uint64_t, float>(domain, rank, nRanks);
     }
 }

--- a/domain/test/integration_mpi/exchange_domain.cpp
+++ b/domain/test/integration_mpi/exchange_domain.cpp
@@ -93,7 +93,7 @@ void exchangeAllToAll(int thisRank, int numRanks)
     {
         int seqStart = rank * gridSize + (gridSize / numRanks) * thisRank;
 
-        for (int i = 0; i < numPartPresent; ++i)
+        for (LocalIndex i = 0; i < numPartPresent; ++i)
             refY.push_back(seqStart++);
     }
 

--- a/domain/test/integration_mpi/exchange_focus.cpp
+++ b/domain/test/integration_mpi/exchange_focus.cpp
@@ -29,7 +29,7 @@ using namespace cstone;
 template<class KeyType>
 void exchangeFocusIrregular(int myRank, int numRanks)
 {
-    std::vector<KeyType> treeLeavesRef[numRanks], treeLeavesInitial[numRanks];
+    std::vector<std::vector<KeyType>> treeLeavesRef(numRanks), treeLeavesInitial(numRanks);
     std::vector<int> peers;
     std::vector<IndexPair<TreeNodeIndex>> peerFocusIndices(numRanks);
 

--- a/domain/test/performance/neighbor_driver.cu
+++ b/domain/test/performance/neighbor_driver.cu
@@ -197,7 +197,7 @@ void benchmarkGpu()
     auto findNeighborsCpu = [&]()
     {
 #pragma omp parallel for
-        for (LocalIndex i = 0; i < n; ++i)
+        for (int i = 0; i < n; ++i)
         {
             neighborsCountCPU[i] = findNeighbors(i, x, y, z, h, nsView, box, ngmax, neighborsCPU.data() + i * ngmax);
         }

--- a/domain/test/performance/octree.cu
+++ b/domain/test/performance/octree.cu
@@ -99,7 +99,7 @@ int main(int argc, char** argv)
     float internalBuildTime = timeGpu(buildInternal);
     std::cout << "internal build time " << internalBuildTime / 1000 << std::endl;
     std::cout << "level ranges: ";
-    for (int i = 0; i <= maxTreeLevel<KeyType>{}; ++i)
+    for (unsigned i = 0; i <= maxTreeLevel<KeyType>{}; ++i)
         std::cout << octree.levelRange[i] << " ";
     std::cout << std::endl;
 
@@ -166,7 +166,7 @@ int main(int argc, char** argv)
     float invTheta = 1.0 / 0.5;
     std::vector<SourceCenterType<double>> h_centers(octree.numNodes);
 #pragma omp parallel for schedule(static)
-    for (size_t i = 0; i < h_octree.numNodes; ++i)
+    for (TreeNodeIndex i = 0; i < h_octree.numNodes; ++i)
     {
         KeyType prefix   = h_octree.prefixes[i];
         KeyType startKey = decodePlaceholderBit(prefix);

--- a/domain/test/unit/neighbors/all_to_all.hpp
+++ b/domain/test/unit/neighbors/all_to_all.hpp
@@ -56,7 +56,7 @@ static void all2allNeighbors(const T* x,
     }
 }
 
-static void sortNeighbors(LocalIndex* neighbors, unsigned* neighborsCount, LocalIndex n, unsigned ngmax)
+inline void sortNeighbors(LocalIndex* neighbors, unsigned* neighborsCount, LocalIndex n, unsigned ngmax)
 {
     for (LocalIndex i = 0; i < n; ++i)
     {

--- a/domain/test/unit_cuda/traversal/groups.cu
+++ b/domain/test/unit_cuda/traversal/groups.cu
@@ -183,7 +183,7 @@ TEST(TargetGroups, makeSplits)
         SplitType splitMask = makeMask(0xFFFFFFFFu, 0x6FFFFFFFu);
 
         makeSplitTester<<<1, 1>>>(splitMask, rawPtr(splitLengths));
-        for (int i = 0; i < targetSize - 1; ++i)
+        for (std::size_t i = 0; i < targetSize - 1; ++i)
         {
             if (i == 60) { EXPECT_EQ(splitLengths[i], 2); }
             else { EXPECT_EQ(splitLengths[i], 1); }
@@ -194,7 +194,7 @@ TEST(TargetGroups, makeSplits)
         SplitType splitMask = makeMask(0xFFFFFFFF, 0x7FFFFFFF);
 
         makeSplitTester<<<1, 1>>>(splitMask, rawPtr(splitLengths));
-        for (int i = 0; i < targetSize - 1; ++i)
+        for (std::size_t i = 0; i < targetSize - 1; ++i)
         {
             EXPECT_EQ(splitLengths[i], 1);
         }

--- a/domain/test/unit_cuda/tree/csarray.cu
+++ b/domain/test/unit_cuda/tree/csarray.cu
@@ -49,7 +49,7 @@ TEST(CsArrayGpu, computeNodeCountsGpu)
     thrust::device_vector<KeyType> d_cstree = h_cstree;
 
     thrust::host_vector<KeyType> h_particleKeys;
-    for (int nodeIdx = 1; nodeIdx < nNodes(h_cstree) - 1; ++nodeIdx)
+    for (std::size_t nodeIdx = 1; nodeIdx < nNodes(h_cstree) - 1; ++nodeIdx)
     {
         // put 2 particles in each tree node, except the first and last node
         h_particleKeys.push_back(h_cstree[nodeIdx]);

--- a/main/src/init/file_init.hpp
+++ b/main/src/init/file_init.hpp
@@ -204,7 +204,7 @@ public:
                 bool isLast   = (i == numParticlesInFile - 1);
                 long keyDelta = (isLast ? -(keys[i] - keys[i - 1]) : keys[i + 1] - keys[i]) / (numSplits + isLast);
 
-                for (size_t j = 1; j < numSplits; ++j)
+                for (int j = 1; j < numSplits; ++j)
                 {
                     auto [ixj, iyj, izj] = cstone::decodeSfc(cstone::sfcKey(keys[i] + j * keyDelta));
 

--- a/main/src/init/file_init.hpp
+++ b/main/src/init/file_init.hpp
@@ -105,7 +105,7 @@ public:
         readFileAttributes(settings_, h5_fname, reader, false);
     }
 
-    cstone::Box<typename Dataset::RealType> init(int /*rank*/, int numRanks, size_t /*n*/, Dataset& simData,
+    cstone::Box<typename Dataset::RealType> init(int /* rank */, int /* numRanks */, size_t /* n */, Dataset& simData,
                                                  IFileReader* reader) const override
     {
         reader->setStep(h5_fname, initStep, FileMode::collective);
@@ -138,7 +138,7 @@ public:
         readFileAttributes(settings_, h5_fname, reader, false);
     }
 
-    cstone::Box<typename Dataset::RealType> init(int rank, int, size_t, Dataset& simData,
+    cstone::Box<typename Dataset::RealType> init(int /* rank */, int, size_t, Dataset& simData,
                                                  IFileReader* reader) const override
     {
         constexpr bool gpu = cstone::HaveGpu<typename Dataset::AcceleratorType>{};

--- a/main/src/init/gresho_chan.hpp
+++ b/main/src/init/gresho_chan.hpp
@@ -56,7 +56,6 @@ void initGreshoChanFields(Dataset& d, const std::map<std::string, double>& setti
     constexpr bool gpu   = cstone::HaveGpu<typename Dataset::AcceleratorType>{};
     using HydroType      = typename Dataset::HydroType;
     using RealType       = typename Dataset::RealType;
-    using XM1Type        = typename Dataset::XM1Type;
     double ng0           = settings.at("ng0");
     double rho           = settings.at("rho");
     double hInit         = 0.5 * std::cbrt(3. * ng0 * mPart / 4. / M_PI / rho);

--- a/main/src/init/isobaric_cube_init.hpp
+++ b/main/src/init/isobaric_cube_init.hpp
@@ -71,7 +71,6 @@ void initIsobaricCubeFields(Dataset& d, const std::map<std::string, double>& con
     constexpr bool gpu = cstone::HaveGpu<typename Dataset::AcceleratorType>{};
     using T            = typename Dataset::RealType;
     using HydroType    = typename Dataset::HydroType;
-    using XM1Type      = typename Dataset::XM1Type;
 
     T r         = constants.at("r");
     T rhoInt    = constants.at("rhoInt");

--- a/main/src/init/kelvin_helmholtz_init.hpp
+++ b/main/src/init/kelvin_helmholtz_init.hpp
@@ -56,7 +56,6 @@ void initKelvinHelmholtzFields(Dataset& d, const std::map<std::string, double>& 
 {
     constexpr bool gpu = cstone::HaveGpu<typename Dataset::AcceleratorType>{};
     using HydroType    = typename Dataset::HydroType;
-    using XM1Type      = typename Dataset::XM1Type;
     T rhoInt           = constants.at("rhoInt");
     T rhoExt           = constants.at("rhoExt");
     T omega0           = constants.at("omega0");

--- a/main/src/init/noh_init.hpp
+++ b/main/src/init/noh_init.hpp
@@ -70,7 +70,6 @@ void initNohFields(Dataset& d, const std::map<std::string, double>& constants)
     constexpr bool gpu = cstone::HaveGpu<typename Dataset::AcceleratorType>{};
     using T            = typename Dataset::RealType;
     using HydroType    = typename Dataset::HydroType;
-    using XM1Type      = typename Dataset::XM1Type;
 
     double r           = constants.at("r1");
     double totalVolume = 4. * M_PI / 3. * r * r * r;

--- a/main/src/init/sim_init.cpp
+++ b/main/src/init/sim_init.cpp
@@ -161,8 +161,9 @@ std::unique_ptr<ISimInitializer<Dataset>> SimInitializers<Dataset>::makeTDEOrbit
 }
 #else
 template<class Dataset>
-std::unique_ptr<ISimInitializer<Dataset>>
-SimInitializers<Dataset>::makePolytrope(std::string /* glassBlock */, std::string /* settingsFile */, IFileReader* /* reader */)
+std::unique_ptr<ISimInitializer<Dataset>> SimInitializers<Dataset>::makePolytrope(std::string /* glassBlock */,
+                                                                                  std::string /* settingsFile */,
+                                                                                  IFileReader* /* reader */)
 {
     throw std::runtime_error("Missing TDE initializers build option for polytrope\n");
     return nullptr;
@@ -170,7 +171,8 @@ SimInitializers<Dataset>::makePolytrope(std::string /* glassBlock */, std::strin
 
 template<class Dataset>
 std::unique_ptr<ISimInitializer<Dataset>> SimInitializers<Dataset>::makeTDEOrbitInit(const std::string& /* filePath */,
-                                                                                     int /* initStep */, IFileReader* /* reader */)
+                                                                                     int /* initStep */,
+                                                                                     IFileReader* /* reader */)
 {
     throw std::runtime_error("Missing TDE initializers build option for tde-orbit\n");
     return nullptr;

--- a/main/src/init/sim_init.cpp
+++ b/main/src/init/sim_init.cpp
@@ -162,15 +162,15 @@ std::unique_ptr<ISimInitializer<Dataset>> SimInitializers<Dataset>::makeTDEOrbit
 #else
 template<class Dataset>
 std::unique_ptr<ISimInitializer<Dataset>>
-SimInitializers<Dataset>::makePolytrope(std::string glassBlock, std::string settingsFile, IFileReader* reader)
+SimInitializers<Dataset>::makePolytrope(std::string /* glassBlock */, std::string /* settingsFile */, IFileReader* /* reader */)
 {
     throw std::runtime_error("Missing TDE initializers build option for polytrope\n");
     return nullptr;
 }
 
 template<class Dataset>
-std::unique_ptr<ISimInitializer<Dataset>> SimInitializers<Dataset>::makeTDEOrbitInit(const std::string& filePath,
-                                                                                     int initStep, IFileReader* reader)
+std::unique_ptr<ISimInitializer<Dataset>> SimInitializers<Dataset>::makeTDEOrbitInit(const std::string& /* filePath */,
+                                                                                     int /* initStep */, IFileReader* /* reader */)
 {
     throw std::runtime_error("Missing TDE initializers build option for tde-orbit\n");
     return nullptr;

--- a/main/src/init/wind_shock_init.hpp
+++ b/main/src/init/wind_shock_init.hpp
@@ -63,7 +63,6 @@ void initWindShockFields(Dataset& d, const std::map<std::string, double>& consta
     constexpr bool gpu = cstone::HaveGpu<typename Dataset::AcceleratorType>{};
     using T            = typename Dataset::RealType;
     using HydroType    = typename Dataset::HydroType;
-    using XM1Type      = typename Dataset::XM1Type;
 
     T r       = constants.at("r");
     T rSphere = constants.at("rSphere");

--- a/main/src/io/CMakeLists.txt
+++ b/main/src/io/CMakeLists.txt
@@ -16,7 +16,7 @@ endfunction()
 
 add_library(io id_tag_utils.cpp ifile_io_ascii.cpp ifile_io_hdf5.cpp arg_parser.cpp)
 target_include_directories(io PRIVATE ${CSTONE_DIR} ${SPH_EXA_INCLUDE_DIRS} ${MPI_CXX_INCLUDE_PATH})
-target_link_libraries(io PRIVATE ${MPI_CXX_LIBRARIES})
+target_link_libraries(io PRIVATE ${MPI_CXX_LIBRARIES} OpenMP::OpenMP_CXX)
 
 if (CMAKE_CUDA_COMPILER OR CMAKE_HIP_COMPILER)
     add_library(io_gpu OBJECT id_tag_utils.cu)

--- a/main/src/io/h5part_wrapper.hpp
+++ b/main/src/io/h5part_wrapper.hpp
@@ -99,8 +99,8 @@ std::vector<std::string> datasetNames(h5_file_t h5_file)
     std::vector<std::string> setNames(numSets);
     for (int64_t fi = 0; fi < numSets; ++fi)
     {
-        int  maxlen = 256;
-        char fieldName[maxlen];
+        constexpr int maxlen = 256;
+        char          fieldName[maxlen];
         H5PartGetDatasetName(h5_file, fi, fieldName, maxlen);
         setNames[fi] = std::string(fieldName);
     }
@@ -116,10 +116,10 @@ std::vector<std::string> fileAttributeNames(h5_file_t h5_file)
     std::vector<std::string> setNames(numAttributes);
     for (int64_t fi = 0; fi < numAttributes; ++fi)
     {
-        int        maxlen = 256;
-        char       attrName[maxlen];
-        h5_int64_t typeId;
-        h5_size_t  attrSize;
+        constexpr int maxlen = 256;
+        char          attrName[maxlen];
+        h5_int64_t    typeId;
+        h5_size_t     attrSize;
 
         H5GetFileAttribInfo(h5_file, fi, attrName, maxlen, &typeId, &attrSize);
         setNames[fi] = std::string(attrName);
@@ -136,10 +136,10 @@ std::vector<std::string> stepAttributeNames(h5_file_t h5_file)
     std::vector<std::string> setNames(numAttributes);
     for (int64_t fi = 0; fi < numAttributes; ++fi)
     {
-        int        maxlen = 256;
-        char       attrName[maxlen];
-        h5_int64_t typeId;
-        h5_size_t  attrSize;
+        constexpr int maxlen = 256;
+        char          attrName[maxlen];
+        h5_int64_t    typeId;
+        h5_size_t     attrSize;
 
         H5GetStepAttribInfo(h5_file, fi, attrName, maxlen, &typeId, &attrSize);
         setNames[fi] = std::string(attrName);

--- a/main/src/io/ifile_io_ascii.cpp
+++ b/main/src/io/ifile_io_ascii.cpp
@@ -74,12 +74,12 @@ public:
     {
         if (key == "iteration") { iterationStep_ = *std::get<const uint64_t*>(val); }
     }
-    void stepAttribute(const std::string& key, const std::string& val) override {}
+    void stepAttribute(const std::string& /* key */, const std::string& /* val */) override {}
 
-    void fileAttribute(const std::string& key, FieldType val, int64_t /*size*/) override {}
-    void fileAttribute(const std::string& key, const std::string& val) override {}
+    void fileAttribute(const std::string& /* key */, FieldType /* val */, int64_t /*size*/) override {}
+    void fileAttribute(const std::string& /* key */, const std::string& /* val */) override {}
 
-    void writeField(const std::string& /*key*/, FieldType field, int col) override
+    void writeField(const std::string& /* key */, FieldType field, int col) override
     {
         columns_.push_back(col);
         std::visit(

--- a/main/src/io/ifile_io_hdf5.cpp
+++ b/main/src/io/ifile_io_hdf5.cpp
@@ -103,10 +103,7 @@ public:
                 // so we explicitly broadcast the value of rank 0 to all ranks
                 using Type = std::decay_t<decltype(*argp)>;
                 std::vector<Type> arg(size);
-                if (size > 0 && rank_ == 0)
-                {
-                    std::copy(argp, argp + size, arg.data());
-                }
+                if (size > 0 && rank_ == 0) { std::copy(argp, argp + size, arg.data()); }
                 MPI_Bcast(arg.data(), size, MpiType<Type>{}, 0, comm_);
                 fileutils::H5WriteStepAttribT(h5File_, key.c_str(), arg.data(), size);
             },
@@ -335,28 +332,19 @@ public:
             localCount_                       = lastIndex_ - firstIndex_;
             H5PartSetView(h5File_, firstIndex_, lastIndex_ - 1);
         }
-        else
-        {
-            std::tie(firstIndex_, lastIndex_, localCount_) = std::make_tuple(0, globalCount_, globalCount_);
-        }
+        else { std::tie(firstIndex_, lastIndex_, localCount_) = std::make_tuple(0, globalCount_, globalCount_); }
     }
 
     std::vector<std::string> fileAttributes() override
     {
         if (h5File_) { return fileutils::fileAttributeNames(h5File_); }
-        else
-        {
-            throw std::runtime_error("Cannot read file attributes: file not opened\n");
-        }
+        else { throw std::runtime_error("Cannot read file attributes: file not opened\n"); }
     }
 
     std::vector<std::string> stepAttributes() override
     {
         if (h5File_) { return fileutils::stepAttributeNames(h5File_); }
-        else
-        {
-            throw std::runtime_error("Cannot read file attributes: file not opened\n");
-        }
+        else { throw std::runtime_error("Cannot read file attributes: file not opened\n"); }
     }
 
     int64_t fileAttributeSize(const std::string& key) override

--- a/main/src/io/ifile_io_hdf5.cpp
+++ b/main/src/io/ifile_io_hdf5.cpp
@@ -335,19 +335,28 @@ public:
             localCount_                       = lastIndex_ - firstIndex_;
             H5PartSetView(h5File_, firstIndex_, lastIndex_ - 1);
         }
-        else { std::tie(firstIndex_, lastIndex_, localCount_) = std::make_tuple(0, globalCount_, globalCount_); }
+        else
+        {
+            std::tie(firstIndex_, lastIndex_, localCount_) = std::make_tuple(0, globalCount_, globalCount_);
+        }
     }
 
     std::vector<std::string> fileAttributes() override
     {
         if (h5File_) { return fileutils::fileAttributeNames(h5File_); }
-        else { throw std::runtime_error("Cannot read file attributes: file not opened\n"); }
+        else
+        {
+            throw std::runtime_error("Cannot read file attributes: file not opened\n");
+        }
     }
 
     std::vector<std::string> stepAttributes() override
     {
         if (h5File_) { return fileutils::stepAttributeNames(h5File_); }
-        else { throw std::runtime_error("Cannot read file attributes: file not opened\n"); }
+        else
+        {
+            throw std::runtime_error("Cannot read file attributes: file not opened\n");
+        }
     }
 
     int64_t fileAttributeSize(const std::string& key) override
@@ -429,16 +438,16 @@ public:
 private:
     int64_t stepAttributeIndex(const std::string& key)
     {
-        auto    attributes = fileutils::stepAttributeNames(h5File_);
-        int64_t attrIndex  = std::find(attributes.begin(), attributes.end(), key) - attributes.begin();
+        auto        attributes = fileutils::stepAttributeNames(h5File_);
+        std::size_t attrIndex  = std::find(attributes.begin(), attributes.end(), key) - attributes.begin();
         if (attrIndex == attributes.size()) { throw std::out_of_range("Attribute " + key + " does not exist\n"); }
         return attrIndex;
     }
 
     int64_t fileAttributeIndex(const std::string& key)
     {
-        auto    attributes = fileutils::fileAttributeNames(h5File_);
-        int64_t attrIndex  = std::find(attributes.begin(), attributes.end(), key) - attributes.begin();
+        auto        attributes = fileutils::fileAttributeNames(h5File_);
+        std::size_t attrIndex  = std::find(attributes.begin(), attributes.end(), key) - attributes.begin();
         if (attrIndex == attributes.size()) { throw std::out_of_range("Attribute " + key + " does not exist\n"); }
         return attrIndex;
     }

--- a/main/src/observables/wind_bubble_fraction.hpp
+++ b/main/src/observables/wind_bubble_fraction.hpp
@@ -79,8 +79,8 @@ double calculateSurvivingMass(size_t first, size_t last, double rhoBubble, doubl
 
     if constexpr (cstone::HaveGpu<typename Dataset::AcceleratorType>{})
     {
-        bubbleMass = survivingMassGpu(rawPtr(d.temp), rawPtr(d.kx), rawPtr(d.xm),
-                                      rawPtr(d.m), rhoBubble, uWind, first, last);
+        bubbleMass =
+            survivingMassGpu(rawPtr(d.temp), rawPtr(d.kx), rawPtr(d.xm), rawPtr(d.m), rhoBubble, uWind, first, last);
     }
     else
     {
@@ -115,7 +115,7 @@ public:
 
     using T = typename Dataset::RealType;
 
-    void computeAndWrite(Dataset& simData, size_t firstIndex, size_t lastIndex, const cstone::Box<T>& box) override
+    void computeAndWrite(Dataset& simData, size_t firstIndex, size_t lastIndex, const cstone::Box<T>&) override
     {
         auto& d = simData.hydro;
         computeConservedQuantities(firstIndex, lastIndex, d, simData.comm);

--- a/main/src/propagator/gravity_wrapper.hpp
+++ b/main/src/propagator/gravity_wrapper.hpp
@@ -120,16 +120,16 @@ public:
 
     cstone::GroupView computeSpatialGroups(const DataType& d, const DomainType& domain)
     {
-        return mHolder_.computeSpatialGroups(domain.startIndex(), domain.endIndex(), rawPtr(d.x),
-                                             rawPtr(d.y), rawPtr(d.z), rawPtr(d.h),
-                                             domain.focusTree(), domain.layout().data(), domain.box());
+        return mHolder_.computeSpatialGroups(domain.startIndex(), domain.endIndex(), rawPtr(d.x), rawPtr(d.y),
+                                             rawPtr(d.z), rawPtr(d.h), domain.focusTree(), domain.layout().data(),
+                                             domain.box());
     }
 
     void upsweep(const DataType& d, const DomainType& domain)
     {
         const auto& focusTree = domain.focusTree();
-        mHolder_.upsweep(rawPtr(d.x), rawPtr(d.y), rawPtr(d.z), rawPtr(d.m),
-                         domain.globalTree(), focusTree, domain.layout().data());
+        mHolder_.upsweep(rawPtr(d.x), rawPtr(d.y), rawPtr(d.z), rawPtr(d.m), domain.globalTree(), focusTree,
+                         domain.layout().data());
     }
 
     void traverse(cstone::GroupView grp, DataType& d, const DomainType& domain)
@@ -138,10 +138,8 @@ public:
         bool        usePbc    = box.boundaryX() == cstone::BoundaryType::periodic;
         int         numShells = usePbc ? ewaldSettings_.numReplicaShells : 0;
 
-        d.egrav =
-            mHolder_.compute(grp, rawPtr(d.x), rawPtr(d.y), rawPtr(d.z), rawPtr(d.m),
-                             rawPtr(d.h), d.g, numShells, domain.box(), rawPtr(d.ugrav),
-                             rawPtr(d.ax), rawPtr(d.ay), rawPtr(d.az));
+        d.egrav = mHolder_.compute(grp, rawPtr(d.x), rawPtr(d.y), rawPtr(d.z), rawPtr(d.m), rawPtr(d.h), d.g, numShells,
+                                   domain.box(), rawPtr(d.ugrav), rawPtr(d.ax), rawPtr(d.ay), rawPtr(d.az));
 
         auto stats = mHolder_.readStats();
 
@@ -155,9 +153,8 @@ public:
             MType rootM;
             memcpyD2H(mHolder_.deviceMultipoles(), 1, &rootM);
 
-            computeGravityEwaldGpu(makeVec3(rootCenter), rootM, grp, rawPtr(d.x), rawPtr(d.y),
-                                   rawPtr(d.z), rawPtr(d.m), box, d.g, rawPtr(d.ugrav),
-                                   rawPtr(d.ax), rawPtr(d.ay), rawPtr(d.az), &d.egrav,
+            computeGravityEwaldGpu(makeVec3(rootCenter), rootM, grp, rawPtr(d.x), rawPtr(d.y), rawPtr(d.z), rawPtr(d.m),
+                                   box, d.g, rawPtr(d.ugrav), rawPtr(d.ax), rawPtr(d.ay), rawPtr(d.az), &d.egrav,
                                    ewaldSettings_);
         }
 

--- a/main/src/propagator/gravity_wrapper.hpp
+++ b/main/src/propagator/gravity_wrapper.hpp
@@ -52,7 +52,11 @@ public:
 
     cstone::GroupView computeSpatialGroups(const DataType& /*d*/, const DomainType& domain)
     {
-        return {.firstBody = domain.startIndex(), .lastBody = domain.endIndex()};
+        return {.firstBody  = domain.startIndex(),
+                .lastBody   = domain.endIndex(),
+                .numGroups  = 0,
+                .groupStart = nullptr,
+                .groupEnd   = nullptr};
     }
 
     void upsweep(const DataType& d, const DomainType& domain)

--- a/main/src/propagator/ipropagator.hpp
+++ b/main/src/propagator/ipropagator.hpp
@@ -167,7 +167,7 @@ protected:
             if (!indicesDone.empty() && writer->rank() == 0)
             {
                 std::cout << "WARNING: the following fields are not in use and therefore not output: ";
-                for (int fidx = 0; fidx < indicesDone.size() - 1; ++fidx)
+                for (std::size_t fidx = 0; fidx < indicesDone.size() - 1; ++fidx)
                 {
                     std::cout << d.fieldNames[fidx] << ",";
                 }

--- a/main/src/propagator/ipropagator.hpp
+++ b/main/src/propagator/ipropagator.hpp
@@ -79,7 +79,7 @@ public:
     virtual void save(IFileWriter*) {}
 
     //! @brief load internal state from file
-    virtual void load(const std::string& path, IFileReader*) {}
+    virtual void load(const std::string& /* path */, IFileReader*) {}
 
     //! @brief whether conserved quantities are time-synchronized (when completing a full time-step hierarchy)
     virtual bool isSynced() { return true; }

--- a/main/src/propagator/nbody.hpp
+++ b/main/src/propagator/nbody.hpp
@@ -160,8 +160,8 @@ public:
         timer.step("UpdateQuantities");
     }
 
-    void saveFields(IFileWriter* writer, size_t first, size_t last, DataType& simData,
-                    const cstone::Box<T>& /*box*/) override
+    void saveFields(IFileWriter* writer, size_t /* first */, size_t /* last */, DataType& simData,
+                    const cstone::Box<T>& /* box */) override
     {
         Base::outputAllocatedFields(writer, simData);
         timer.step("FileOutput");

--- a/main/src/propagator/std_hydro.hpp
+++ b/main/src/propagator/std_hydro.hpp
@@ -184,8 +184,8 @@ public:
         timer.step("UpdateQuantities");
     }
 
-    void saveFields(IFileWriter* writer, size_t first, size_t last, DataType& simData,
-                    const cstone::Box<T>& /*box*/) override
+    void saveFields(IFileWriter* writer, size_t /* first */, size_t /* last */, DataType& simData,
+                    const cstone::Box<T>& /* box */) override
     {
         Base::outputAllocatedFields(writer, simData);
         timer.step("FileOutput");

--- a/main/src/propagator/ve_hydro.hpp
+++ b/main/src/propagator/ve_hydro.hpp
@@ -275,7 +275,7 @@ public:
         if (!indicesDone.empty() && Base::rank_ == 0)
         {
             std::cout << "WARNING: the following fields are not in use and therefore not output: ";
-            for (int fidx = 0; fidx < indicesDone.size() - 1; ++fidx)
+            for (std::size_t fidx = 0; fidx < indicesDone.size() - 1; ++fidx)
             {
                 std::cout << d.fieldNames[fidx] << ",";
             }

--- a/main/src/propagator/ve_hydro_bdt.hpp
+++ b/main/src/propagator/ve_hydro_bdt.hpp
@@ -195,8 +195,7 @@ public:
         domain.exchangeHalos(get<"x", "y", "z", "h">(d), get<"keys">(d), haloRecvScratch);
         if (d.g != 0.0)
         {
-            domain.updateExpansionCenters(get<"x">(d), get<"y">(d), get<"z">(d), get<"m">(d), get<"keys">(d),
-                                          haloRecvScratch);
+            domain.updateExpansionCenters(get<"x">(d), get<"y">(d), get<"z">(d), get<"m">(d), get<"keys">(d));
         }
 
         //! @brief increase tree-cell search radius for each substep to account for particles drifting out of cells

--- a/main/src/propagator/ve_hydro_bdt.hpp
+++ b/main/src/propagator/ve_hydro_bdt.hpp
@@ -437,7 +437,7 @@ public:
         if (!indicesDone.empty() && Base::rank_ == 0)
         {
             std::cout << "WARNING: the following fields are not in use and therefore not output: ";
-            for (int fidx = 0; fidx < indicesDone.size() - 1; ++fidx)
+            for (std::size_t fidx = 0; fidx < indicesDone.size() - 1; ++fidx)
             {
                 std::cout << d.fieldNames[fidx] << ",";
             }

--- a/main/src/propagator/ve_hydro_bdt.hpp
+++ b/main/src/propagator/ve_hydro_bdt.hpp
@@ -249,7 +249,8 @@ public:
         groupDivvTimestep(activeRungs_, rawPtr(groupDt_), d);
         timer.step("IadVelocityDivCurlGradh");
 
-        domain.exchangeHalos(get<"c11", "c12", "c13", "c22", "c23", "c33", "divv", "gradh">(d), get<"keys">(d), haloRecvScratch);
+        domain.exchangeHalos(get<"c11", "c12", "c13", "c22", "c23", "c33", "divv", "gradh">(d), get<"keys">(d),
+                             haloRecvScratch);
         timer.step("mpi::synchronizeHalos");
 
         computeEOS(first, last, d);

--- a/main/src/sphexa/sphexa.cpp
+++ b/main/src/sphexa/sphexa.cpp
@@ -201,7 +201,7 @@ int main(int argc, char** argv)
 //! @brief check whether the stop conditions based on evolved time (not wall-clock) or iteration count are reached
 bool stopConditionReached(size_t iteration, double time, const std::string& maxStepStr)
 {
-    bool lastIteration = strIsIntegral(maxStepStr) && iteration >= std::stoi(maxStepStr);
+    bool lastIteration = strIsIntegral(maxStepStr) && iteration >= std::stoull(maxStepStr);
     bool simTimeLimit  = !strIsIntegral(maxStepStr) && time > std::stod(maxStepStr);
 
     return lastIteration || simTimeLimit;

--- a/ryoanji/test/demo.cu
+++ b/ryoanji/test/demo.cu
@@ -136,7 +136,7 @@ int main(int argc, char** argv)
     std::vector<double> delta(numBodies);
 
     double potentialSum = 0;
-    for (int i = 0; i < numBodies; i++)
+    for (std::size_t i = 0; i < numBodies; i++)
     {
         potentialSum += h_p[i];
         Vec3<T> ref   = {h_refAx[i], h_refAy[i], h_refAz[i]};

--- a/ryoanji/test/demo_mpi.cpp
+++ b/ryoanji/test/demo_mpi.cpp
@@ -50,7 +50,8 @@ void ryoanjiTest(int thisRank, int numRanks, size_t numParticlesGlobal)
     std::vector<T> h(numParticles, hmean);
     std::vector<T> m(numParticles, 1.0f / float(numParticlesGlobal));
 
-    cstone::Domain<KeyType, T, AccType> domain(thisRank, numRanks, bucketSizeGlobal, bucketSizeFocus, theta, MPI_COMM_WORLD, box);
+    cstone::Domain<KeyType, T, AccType> domain(thisRank, numRanks, bucketSizeGlobal, bucketSizeFocus, theta,
+                                               MPI_COMM_WORLD, box);
 
     // upload particles to GPU
     cstone::DeviceVector<KeyType> d_keys = std::vector<KeyType>(numParticles);
@@ -72,15 +73,13 @@ void ryoanjiTest(int thisRank, int numRanks, size_t numParticlesGlobal)
 
     //! includes tree plus associated information, like nearby ranks, assignment, counts, MAC spheres, etc
     const cstone::FocusedOctree<KeyType, T, cstone::GpuTag>& focusTree = domain.focusTree();
-    //! the focused octree on GPU, structure only
-    auto octree = focusTree.octreeViewAcc();
 
     MultipoleHolder<T, T, T, T, T, KeyType, MultipoleType> multipoleHolder;
 
-    auto grp = multipoleHolder.computeSpatialGroups(domain.startIndex(), domain.endIndex(), rawPtr(d_x), rawPtr(d_y),
-                                                    rawPtr(d_z), rawPtr(d_h), domain.focusTree(),
-                                                    domain.layout().data(), domain.box());
-    multipoleHolder.upsweep(rawPtr(d_x), rawPtr(d_y), rawPtr(d_z), rawPtr(d_m), domain.globalTree(), domain.focusTree(),
+    auto grp =
+        multipoleHolder.computeSpatialGroups(domain.startIndex(), domain.endIndex(), rawPtr(d_x), rawPtr(d_y),
+                                             rawPtr(d_z), rawPtr(d_h), focusTree, domain.layout().data(), domain.box());
+    multipoleHolder.upsweep(rawPtr(d_x), rawPtr(d_y), rawPtr(d_z), rawPtr(d_m), domain.globalTree(), focusTree,
                             domain.layout().data());
 
     auto t0 = std::chrono::high_resolution_clock::now();

--- a/ryoanji/test/interface/global_forces_gpu.cpp
+++ b/ryoanji/test/interface/global_forces_gpu.cpp
@@ -182,7 +182,7 @@ static int multipoleHolderTest(int thisRank, int numRanks)
 
         double         potentialSumRef = 0;
         std::vector<T> errors(ax.size()), errors_cpu(ax.size());
-        for (int i = 0; i < ax.size(); i++)
+        for (std::size_t i = 0; i < ax.size(); i++)
         {
             potentialSumRef += pRef[i];
             Vec3<T> ref       = {axRef[i], ayRef[i], azRef[i]};
@@ -270,7 +270,7 @@ static int multipoleHolderTest(int thisRank, int numRanks)
             std::vector<T> azt = toHost(d_azt);
 
             bool passTargets = true;
-            for (int i = 0; i < numTargets; i++)
+            for (LocalIndex i = 0; i < numTargets; i++)
             {
                 Vec3<T> ref   = {axRef[i], ayRef[i], azRef[i]};
                 Vec3<T> probe = {axt[i], ayt[i], azt[i]};

--- a/ryoanji/test/interface/global_forces_gpu.cpp
+++ b/ryoanji/test/interface/global_forces_gpu.cpp
@@ -295,7 +295,7 @@ static int multipoleHolderTest(int thisRank, int numRanks)
 
 int main(int argc, char** argv)
 {
-    MPI_Init(NULL, NULL);
+    MPI_Init(&argc, &argv);
 
     int rank = 0, numRanks = 0;
     MPI_Comm_rank(MPI_COMM_WORLD, &rank);

--- a/ryoanji/test/interface/global_forces_gpu.cpp
+++ b/ryoanji/test/interface/global_forces_gpu.cpp
@@ -64,7 +64,8 @@ static int multipoleHolderTest(int thisRank, int numRanks)
     std::vector<T>       m(globalMasses.begin() + firstIndex, globalMasses.begin() + lastIndex);
     std::vector<KeyType> h_keys(x.size());
 
-    cstone::Domain<KeyType, T, cstone::GpuTag> domain(thisRank, numRanks, bucketSize, bucketSizeLocal, theta, MPI_COMM_WORLD, box);
+    cstone::Domain<KeyType, T, cstone::GpuTag> domain(thisRank, numRanks, bucketSize, bucketSizeLocal, theta,
+                                                      MPI_COMM_WORLD, box);
 
     MultipoleHolder<T, T, T, T, T, KeyType, MultipoleType> multipoleHolder;
 

--- a/ryoanji/test/interface/global_upsweep_cpu.cpp
+++ b/ryoanji/test/interface/global_upsweep_cpu.cpp
@@ -101,7 +101,7 @@ static int multipoleExchangeTest(int thisRank, int numRanks)
 
 int main(int argc, char** argv)
 {
-    MPI_Init(NULL, NULL);
+    MPI_Init(&argc, &argv);
 
     int rank = 0, numRanks = 0;
     MPI_Comm_rank(MPI_COMM_WORLD, &rank);

--- a/ryoanji/test/interface/global_upsweep_gpu.cpp
+++ b/ryoanji/test/interface/global_upsweep_gpu.cpp
@@ -112,7 +112,7 @@ static int multipoleHolderTest(int thisRank, int numRanks)
 
 int main(int argc, char** argv)
 {
-    MPI_Init(NULL, NULL);
+    MPI_Init(&argc, &argv);
 
     int rank = 0, numRanks = 0;
     MPI_Comm_rank(MPI_COMM_WORLD, &rank);

--- a/ryoanji/test/interface/global_upsweep_gpu.cpp
+++ b/ryoanji/test/interface/global_upsweep_gpu.cpp
@@ -57,7 +57,8 @@ static int multipoleHolderTest(int thisRank, int numRanks)
 
     std::vector<KeyType> particleKeys(x.size());
 
-    cstone::Domain<KeyType, T, cstone::GpuTag> domain(thisRank, numRanks, bucketSize, bucketSizeLocal, theta, MPI_COMM_WORLD, box);
+    cstone::Domain<KeyType, T, cstone::GpuTag> domain(thisRank, numRanks, bucketSize, bucketSizeLocal, theta,
+                                                      MPI_COMM_WORLD, box);
 
     MultipoleHolder<T, T, T, T, T, KeyType, MultipoleType> multipoleHolder;
 

--- a/ryoanji/test/nbody/direct.cu
+++ b/ryoanji/test/nbody/direct.cu
@@ -54,7 +54,7 @@ TEST(DirectSum, MatchCpu)
     directSum(x.data(), y.data(), z.data(), h.data(), m.data(), numBodies, G, box, numShells, refAx.data(),
               refAy.data(), refAz.data(), refP.data());
 
-    for (int i = 0; i < numBodies; ++i)
+    for (std::size_t i = 0; i < numBodies; ++i)
     {
         EXPECT_NEAR(h_ax[i], refAx[i], 1e-6);
         EXPECT_NEAR(h_ay[i], refAy[i], 1e-6);

--- a/ryoanji/test/nbody/ewald.cu
+++ b/ryoanji/test/nbody/ewald.cu
@@ -74,7 +74,7 @@ TEST(Ewald, MatchCpu)
 
     EXPECT_NEAR(utotRef, utot, 1e-7);
 
-    for (int i = 0; i < numBodies; ++i)
+    for (std::size_t i = 0; i < numBodies; ++i)
     {
         EXPECT_NEAR(h_p[i], refP[i], 1e-6);
         EXPECT_NEAR(h_ax[i], refAx[i], 1e-6);

--- a/sph/include/sph/hydro_std/momentum_energy.hpp
+++ b/sph/include/sph/hydro_std/momentum_energy.hpp
@@ -118,8 +118,8 @@ void relaxSystem(size_t startIndex, size_t endIndex, Dataset& d, double relaxati
     if (relaxationTimescale <= 0.) return;
     if constexpr (cstone::HaveGpu<typename Dataset::AcceleratorType>{})
     {
-        relaxSystemGPU(startIndex, endIndex, rawPtr(d.ax), rawPtr(d.ay), rawPtr(d.az),
-                       rawPtr(d.vx), rawPtr(d.vy), rawPtr(d.vz), relaxationTimescale);
+        relaxSystemGPU(startIndex, endIndex, rawPtr(d.ax), rawPtr(d.ay), rawPtr(d.az), rawPtr(d.vx), rawPtr(d.vy),
+                       rawPtr(d.vz), relaxationTimescale);
     }
     else { relaxSystemImpl(startIndex, endIndex, d, relaxationTimescale); }
 }

--- a/sph/include/sph/hydro_std/momentum_energy.hpp
+++ b/sph/include/sph/hydro_std/momentum_energy.hpp
@@ -103,7 +103,6 @@ void computeMomentumEnergySTD(const GroupView& groups, Dataset& d, const cstone:
 template<typename Dataset>
 void relaxSystemImpl(size_t first, size_t last, Dataset& d, double relaxationTimescale)
 {
-    using T = std::decay_t<decltype(d.vx[0])>;
 #pragma omp parallel for
     for (size_t i = first; i < last; i++)
     {

--- a/sph/include/sph/hydro_ve/momentum_energy.hpp
+++ b/sph/include/sph/hydro_ve/momentum_energy.hpp
@@ -77,9 +77,9 @@ void computeMomentumEnergyImpl(size_t startIndex, size_t endIndex, Dataset& d, c
     auto* grad_P_y = d.ay.data();
     auto* grad_P_z = d.az.data();
 
-    const auto* wh  = d.wh.data();
-    const auto* kx  = d.kx.data();
-    const auto* xm  = d.xm.data();
+    const auto* wh = d.wh.data();
+    const auto* kx = d.kx.data();
+    const auto* xm = d.xm.data();
 
     T minDt = INFINITY;
 

--- a/sph/include/sph/hydro_ve/momentum_energy.hpp
+++ b/sph/include/sph/hydro_ve/momentum_energy.hpp
@@ -78,7 +78,6 @@ void computeMomentumEnergyImpl(size_t startIndex, size_t endIndex, Dataset& d, c
     auto* grad_P_z = d.az.data();
 
     const auto* wh  = d.wh.data();
-    const auto* whd = d.whd.data();
     const auto* kx  = d.kx.data();
     const auto* xm  = d.xm.data();
 

--- a/sph/include/sph/hydro_ve/ve.hpp
+++ b/sph/include/sph/hydro_ve/ve.hpp
@@ -54,7 +54,6 @@ void computeVeImpl(size_t startIndex, size_t endIndex, Dataset& d, const cstone:
     auto* kx    = d.kx.data();
 
     const Tc K         = d.K;
-    const Tc sincIndex = d.sincIndex;
 
 #pragma omp parallel for
     for (size_t i = startIndex; i < endIndex; i++)

--- a/sph/include/sph/hydro_ve/ve.hpp
+++ b/sph/include/sph/hydro_ve/ve.hpp
@@ -47,20 +47,20 @@ void computeVeImpl(size_t startIndex, size_t endIndex, Dataset& d, const cstone:
     const auto* z = d.z.data();
     const auto* h = d.h.data();
 
-    const auto* wh  = d.wh.data();
+    const auto* wh = d.wh.data();
 
     const auto* xm = d.xm.data();
 
-    auto* kx    = d.kx.data();
+    auto* kx = d.kx.data();
 
-    const Tc K         = d.K;
+    const Tc K = d.K;
 
 #pragma omp parallel for
     for (size_t i = startIndex; i < endIndex; i++)
     {
-        size_t   ni        = i - startIndex;
-        unsigned ncCapped  = std::min(neighborsCount[i] - 1, d.ngmax);
-        auto kxi = veJLoop(i, K, box, neighbors + d.ngmax * ni, ncCapped, x, y, z, h, wh, xm);
+        size_t   ni       = i - startIndex;
+        unsigned ncCapped = std::min(neighborsCount[i] - 1, d.ngmax);
+        auto     kxi      = veJLoop(i, K, box, neighbors + d.ngmax * ni, ncCapped, x, y, z, h, wh, xm);
 
         kx[i] = kxi;
     }

--- a/sph/include/sph/timestep.h
+++ b/sph/include/sph/timestep.h
@@ -23,7 +23,7 @@ struct Timestep
     int   substep{0};
 
     std::array<cstone::LocalIndex, maxNumRungs + 1> rungRanges;
-    util::array<float, maxNumRungs>                 dt_m1, dt_drift;
+    util::array<float, maxNumRungs>                 dt_m1 = {}, dt_drift = {};
 
     template<class Archive>
     void loadOrStore(Archive* ar, const std::string& prefix)

--- a/sph/include/sph/ts_rungs.hpp
+++ b/sph/include/sph/ts_rungs.hpp
@@ -33,7 +33,7 @@
 
 #include <algorithm>
 #include <cmath>
-#include <vector>
+#include <limits>
 #include <mpi.h>
 
 #include "cstone/primitives/math.hpp"

--- a/sph/include/sph/ts_rungs.hpp
+++ b/sph/include/sph/ts_rungs.hpp
@@ -61,8 +61,7 @@ void groupAccTimestep(const GroupView& grp, float* groupDt, const Dataset& d)
 {
     if constexpr (cstone::HaveGpu<typename Dataset::AcceleratorType>{})
     {
-        groupAccTimestepGpu(d.etaAcc, grp, rawPtr(d.ax), rawPtr(d.ay), rawPtr(d.az),
-                            rawPtr(d.h), groupDt);
+        groupAccTimestepGpu(d.etaAcc, grp, rawPtr(d.ax), rawPtr(d.ay), rawPtr(d.az), rawPtr(d.h), groupDt);
     }
 }
 
@@ -100,7 +99,7 @@ auto computeMinTimestep(float* groupDt, LocalIndex* groupIndices, LocalIndex num
                         AccVec& scratch)
 {
     float                fastFraction = 0.4;
-    std::array<float, 2> minGroupDt;
+    std::array<float, 2> minGroupDt   = {std::numeric_limits<float>::max(), std::numeric_limits<float>::max()};
     if constexpr (IsDeviceVector<AccVec>{})
     {
         sortGroupDt(groupDt, groupIndices, numGroups, scratch);

--- a/sph/test/hydro_turb/rng.cpp
+++ b/sph/test/hydro_turb/rng.cpp
@@ -29,6 +29,7 @@
  * @author Sebastian Keller <sebastian.f.keller@gmail.com>
  */
 
+#include <memory>
 #include <random>
 #include <sstream>
 
@@ -56,11 +57,11 @@ TEST(Turbulence, rngSerialize)
     EXPECT_NE(originalEngine, engine);
 
     // check conversion from char array, as that's what's going to be read from HDF5
-    char stateChar[engineState.size()];
-    std::copy(engineState.begin(), engineState.end(), stateChar);
+    auto stateChar = std::make_unique<char[]>(engineState.size());
+    std::copy(engineState.begin(), engineState.end(), stateChar.get());
 
     std::stringstream t;
-    t << stateChar;
+    t << stateChar.get();
     t >> engine;
 
     EXPECT_EQ(originalEngine, engine);

--- a/sph/test/hydro_turb/rng.cpp
+++ b/sph/test/hydro_turb/rng.cpp
@@ -61,7 +61,7 @@ TEST(Turbulence, rngSerialize)
     std::copy(engineState.begin(), engineState.end(), stateChar.get());
 
     std::stringstream t;
-    t << stateChar.get();
+    t.write(stateChar.get(), engineState.size());
     t >> engine;
 
     EXPECT_EQ(originalEngine, engine);


### PR DESCRIPTION
Fixes all compiler warnings (tested with GCC `-Wall -Wextra -pedantic -Werror`).

- Fixes many comparisons of signed and unsigned integers.
- Removes all occurences of non-standard variable-length arrays (VLAs).
- Fixes an incorrect OpenMP pragma.
- Fixes disabled OpenMP in IO library.
- Removes an unused scratch vector from `Domain::updateExpansionCenters` and `FocusedOctree::updateCenters`.
- Further removes unused variables and fixes non-initialized struct members.