### PR TITLE
Reuse init at rest in initializers

### DIFF
--- a/main/src/init/evrard_init.hpp
+++ b/main/src/init/evrard_init.hpp
@@ -32,38 +32,22 @@ InitSettings evrardConstants()
 }
 
 template<class Dataset>
-void initEvrardFields(Dataset& d, const std::map<std::string, double>& constants)
+void initEvrardFields(Dataset& d, const InitSettings& constants)
 {
     constexpr bool gpu = cstone::HaveGpu<typename Dataset::AcceleratorType>{};
-    using T            = typename Dataset::RealType;
 
-    double mPart = constants.at("mTotal") / d.numParticlesGlobal;
-
-    cstone::fill<gpu>(d.m.begin(), d.m.end(), mPart);
-    cstone::fill<gpu>(d.du_m1.begin(), d.du_m1.end(), 0.0);
-    cstone::fill<gpu>(d.mui.begin(), d.mui.end(), d.muiConst);
-    cstone::fill<gpu>(d.alpha.begin(), d.alpha.end(), d.alphamin);
-
-    cstone::fill<gpu>(d.vx.begin(), d.vx.end(), 0.0);
-    cstone::fill<gpu>(d.vy.begin(), d.vy.end(), 0.0);
-    cstone::fill<gpu>(d.vz.begin(), d.vz.end(), 0.0);
-
-    cstone::fill<gpu>(d.x_m1.begin(), d.x_m1.end(), 0.0);
-    cstone::fill<gpu>(d.y_m1.begin(), d.y_m1.end(), 0.0);
-    cstone::fill<gpu>(d.z_m1.begin(), d.z_m1.end(), 0.0);
-
-    generateParticleIDs<gpu>(d.id);
+    initFieldsAtRest(d, constants.at("mTotal") / d.numParticlesGlobal);
 
     auto cv    = sph::idealGasCv(d.muiConst, d.gamma);
     auto temp0 = constants.at("u0") / cv;
     cstone::fill<gpu>(d.temp.begin(), d.temp.end(), temp0);
     cstone::fill<gpu>(d.u.begin(), d.u.end(), constants.at("u0"));
 
-    T totalVolume = 4 * M_PI / 3 * std::pow(constants.at("r"), 3);
+    double totalVolume = 4 * M_PI / 3 * std::pow(constants.at("r"), 3);
     // before the contraction with sqrt(r), the sphere has a constant particle concentration of Ntot / Vtot
     // after shifting particles towards the center by factor sqrt(r), the local concentration becomes
     // c(r) = 2/3 * 1/r * Ntot / Vtot
-    T c0 = 2. / 3. * d.numParticlesGlobal / totalVolume;
+    double c0 = 2. / 3. * d.numParticlesGlobal / totalVolume;
 
     auto&&                                   x = toHost(d.x);
     auto&&                                   y = toHost(d.y);
@@ -72,9 +56,9 @@ void initEvrardFields(Dataset& d, const std::map<std::string, double>& constants
 #pragma omp parallel for schedule(static)
     for (size_t i = 0; i < d.x.size(); i++)
     {
-        T radius        = std::sqrt(x[i] * x[i] + y[i] * y[i] + z[i] * z[i]);
-        T concentration = c0 / radius;
-        h[i]            = std::cbrt(3 / (4 * M_PI) * d.ng0 / concentration) * 0.5;
+        auto radius        = std::sqrt(x[i] * x[i] + y[i] * y[i] + z[i] * z[i]);
+        auto concentration = c0 / radius;
+        h[i]               = std::cbrt(3 / (4 * M_PI) * d.ng0 / concentration) * 0.5;
     }
 
     d.h = std::move(h);

--- a/main/src/init/gresho_chan.hpp
+++ b/main/src/init/gresho_chan.hpp
@@ -33,6 +33,7 @@
 #include "cstone/sfc/box.hpp"
 #include "isim_init.hpp"
 #include "grid.hpp"
+#include "utils.hpp"
 #include "sph/eos.hpp"
 
 namespace sphexa

--- a/main/src/init/gresho_chan.hpp
+++ b/main/src/init/gresho_chan.hpp
@@ -44,18 +44,12 @@ InitSettings GreshoChanSettings()
             {"rho", 1},  {"Kcour", 0.2}, {"ng0", 100}, {"ngmax", 150},     {"gravConstant", 0.0}, {"gresho-chan", 1.0}};
 }
 
-template<class T>
-double twoDimRadius(T x, T y)
-{
-    return std::sqrt(x * x + y * y);
-}
-
 template<class Dataset, class T>
 void initGreshoChanFields(Dataset& d, const std::map<std::string, double>& settings, T mPart)
 {
     constexpr bool gpu   = cstone::HaveGpu<typename Dataset::AcceleratorType>{};
-    using HydroType      = typename Dataset::HydroType;
-    using RealType       = typename Dataset::RealType;
+    using HydroType      = Dataset::HydroType;
+    using RealType       = Dataset::RealType;
     double ng0           = settings.at("ng0");
     double rho           = settings.at("rho");
     double hInit         = 0.5 * std::cbrt(3. * ng0 * mPart / 4. / M_PI / rho);
@@ -70,15 +64,8 @@ void initGreshoChanFields(Dataset& d, const std::map<std::string, double>& setti
     double v0 = settings.at("v0");
     double P0 = settings.at("P0");
 
-    cstone::fill<gpu>(d.m.begin(), d.m.end(), mPart);
-    cstone::fill<gpu>(d.du_m1.begin(), d.du_m1.end(), 0.0);
+    initFieldsAtRest(d, mPart);
     cstone::fill<gpu>(d.h.begin(), d.h.end(), hInit);
-    cstone::fill<gpu>(d.mui.begin(), d.mui.end(), d.muiConst);
-    cstone::fill<gpu>(d.alpha.begin(), d.alpha.end(), d.alphamin);
-    cstone::fill<gpu>(d.vz.begin(), d.vz.end(), 0.0);
-    cstone::fill<gpu>(d.z_m1.begin(), d.z_m1.end(), 0.0);
-
-    generateParticleIDs<gpu>(d.id);
 
     auto&& x = toHost(d.x);
     auto&& y = toHost(d.y);
@@ -93,7 +80,7 @@ void initGreshoChanFields(Dataset& d, const std::map<std::string, double>& setti
         T vi, pi;
         T xi    = x[i];
         T yi    = y[i];
-        T psi   = twoDimRadius(xi, yi) / R1;
+        T psi   = std::sqrt(norm2(util::array<T, 2>{xi, yi})) / R1;
         T theta = std::atan2(yi, xi);
 
         if (psi <= 1.)

--- a/main/src/init/isobaric_cube_init.hpp
+++ b/main/src/init/isobaric_cube_init.hpp
@@ -84,19 +84,7 @@ void initIsobaricCubeFields(Dataset& d, const std::map<std::string, double>& con
     T epsilon   = constants.at("epsilon");
 
     auto cv = sph::idealGasCv(d.muiConst, d.gamma);
-
-    cstone::fill<gpu>(d.m.begin(), d.m.end(), massPart);
-    cstone::fill<gpu>(d.du_m1.begin(), d.du_m1.end(), 0.0);
-    cstone::fill<gpu>(d.mui.begin(), d.mui.end(), d.muiConst);
-    cstone::fill<gpu>(d.alpha.begin(), d.alpha.end(), d.alphamin);
-    cstone::fill<gpu>(d.vx.begin(), d.vx.end(), 0.0);
-    cstone::fill<gpu>(d.vy.begin(), d.vy.end(), 0.0);
-    cstone::fill<gpu>(d.vz.begin(), d.vz.end(), 0.0);
-    cstone::fill<gpu>(d.x_m1.begin(), d.x_m1.end(), 0.0);
-    cstone::fill<gpu>(d.y_m1.begin(), d.y_m1.end(), 0.0);
-    cstone::fill<gpu>(d.z_m1.begin(), d.z_m1.end(), 0.0);
-
-    generateParticleIDs<gpu>(d.id);
+    initFieldsAtRest(d, massPart);
 
     auto&&                 x = toHost(d.x);
     auto&&                 y = toHost(d.y);

--- a/main/src/init/kelvin_helmholtz_init.hpp
+++ b/main/src/init/kelvin_helmholtz_init.hpp
@@ -52,10 +52,10 @@ InitSettings KelvinHelmholtzConstants()
 }
 
 template<class T, class Dataset>
-void initKelvinHelmholtzFields(Dataset& d, const std::map<std::string, double>& constants, T massPart)
+void initKelvinHelmholtzFields(Dataset& d, const InitSettings& constants, T massPart)
 {
     constexpr bool gpu = cstone::HaveGpu<typename Dataset::AcceleratorType>{};
-    using HydroType    = typename Dataset::HydroType;
+    using HydroType    = Dataset::HydroType;
     T rhoInt           = constants.at("rhoInt");
     T rhoExt           = constants.at("rhoExt");
     T omega0           = constants.at("omega0");
@@ -72,15 +72,9 @@ void initKelvinHelmholtzFields(Dataset& d, const std::map<std::string, double>& 
     T hInt = 0.5 * std::cbrt(3. * d.ng0 * massPart / 4. / M_PI / rhoInt);
     T hExt = 0.5 * std::cbrt(3. * d.ng0 * massPart / 4. / M_PI / rhoExt);
 
-    cstone::fill<gpu>(d.m.begin(), d.m.end(), massPart);
-    cstone::fill<gpu>(d.du_m1.begin(), d.du_m1.end(), 0.0);
+    initFieldsAtRest(d, massPart);
     cstone::fill<gpu>(d.mue.begin(), d.mue.end(), 2.0);
     cstone::fill<gpu>(d.mui.begin(), d.mui.end(), 10.0);
-    cstone::fill<gpu>(d.alpha.begin(), d.alpha.end(), d.alphamax);
-    cstone::fill<gpu>(d.vz.begin(), d.vz.end(), 0.0);
-    cstone::fill<gpu>(d.z_m1.begin(), d.z_m1.end(), 0.0);
-
-    generateParticleIDs<gpu>(d.id);
 
     auto   cv = sph::idealGasCv(d.muiConst, gamma);
     auto&& x  = toHost(d.x);

--- a/main/src/init/polytrope_init.hpp
+++ b/main/src/init/polytrope_init.hpp
@@ -28,29 +28,6 @@ InitSettings polytropeConstants()
             {"eosChoice", sph::EosType::polytropic}};
 }
 
-template<class Dataset>
-void initPolytropeFields(Dataset& d, const std::map<std::string, double>& constants, double m_part)
-{
-    constexpr bool gpu = cstone::HaveGpu<typename Dataset::AcceleratorType>{};
-
-    cstone::fill<gpu>(d.m.begin(), d.m.end(), m_part);
-    cstone::fill<gpu>(d.du_m1.begin(), d.du_m1.end(), 0.0);
-    cstone::fill<gpu>(d.mui.begin(), d.mui.end(), d.muiConst);
-    cstone::fill<gpu>(d.alpha.begin(), d.alpha.end(), d.alphamin);
-
-    cstone::fill<gpu>(d.vx.begin(), d.vx.end(), 0.0);
-    cstone::fill<gpu>(d.vy.begin(), d.vy.end(), 0.0);
-    cstone::fill<gpu>(d.vz.begin(), d.vz.end(), 0.0);
-
-    cstone::fill<gpu>(d.x_m1.begin(), d.x_m1.end(), 0.0);
-    cstone::fill<gpu>(d.y_m1.begin(), d.y_m1.end(), 0.0);
-    cstone::fill<gpu>(d.z_m1.begin(), d.z_m1.end(), 0.0);
-
-    cstone::fill<gpu>(d.u.begin(), d.u.end(), 0.0);
-
-    generateParticleIDs<gpu>(d.id);
-}
-
 template<typename Dataset>
 void estimateSmoothingLengths(auto rhoAtRadius, Dataset& d, double m_part, size_t ng0, double r_total)
 {
@@ -138,7 +115,7 @@ public:
 
         const double m_part = m_total / settings_.at("numParticlesGlobal");
         estimateSmoothingLengths(rho_r, simData.hydro, m_part, settings_.at("ng0"), r_total);
-        initPolytropeFields(simData.hydro, settings_, m_part);
+        initFieldsAtRest(simData.hydro, m_part);
 
         return globalBox;
     }

--- a/main/src/init/sedov_init.hpp
+++ b/main/src/init/sedov_init.hpp
@@ -47,10 +47,10 @@ namespace sphexa
 {
 
 template<class Dataset>
-void initSedovFields(Dataset& d, const std::map<std::string, double>& constants)
+void initSedovFields(Dataset& d, const InitSettings& constants)
 {
     constexpr bool gpu = cstone::HaveGpu<typename Dataset::AcceleratorType>{};
-    using T            = typename Dataset::RealType;
+    using T            = Dataset::RealType;
 
     double r           = constants.at("r1");
     double totalVolume = std::pow(2 * r, 3);
@@ -63,25 +63,10 @@ void initSedovFields(Dataset& d, const std::map<std::string, double>& constants)
     // We distribute energy as exp(-r2 / width2), with width taken as the current 2h, so that the enery
     // is deposited in about ng0 neighbors.
     // ener0 is the constant that should multiply the Gaussian so that its integral equals energytotal
-    double ener0  = constants.at("energyTotal") / std::pow(M_PI, 1.5) / width2 / width;
+    double ener0 = constants.at("energyTotal") / std::pow(M_PI, 1.5) / width2 / width;
 
-
-    cstone::fill<gpu>(d.m.begin(), d.m.end(), mPart);
+    initFieldsAtRest(d, mPart);
     cstone::fill<gpu>(d.h.begin(), d.h.end(), hInit);
-    cstone::fill<gpu>(d.du_m1.begin(), d.du_m1.end(), 0.0);
-    cstone::fill<gpu>(d.mui.begin(), d.mui.end(), d.muiConst);
-    cstone::fill<gpu>(d.alpha.begin(), d.alpha.end(), d.alphamin);
-
-    cstone::fill<gpu>(d.vx.begin(), d.vx.end(), 0.0);
-    cstone::fill<gpu>(d.vy.begin(), d.vy.end(), 0.0);
-    cstone::fill<gpu>(d.vz.begin(), d.vz.end(), 0.0);
-
-    // general form: d.x_m1[i] = d.vx[i] * firstTimeStep;
-    cstone::fill<gpu>(d.x_m1.begin(), d.x_m1.end(), 0.0);
-    cstone::fill<gpu>(d.y_m1.begin(), d.y_m1.end(), 0.0);
-    cstone::fill<gpu>(d.z_m1.begin(), d.z_m1.end(), 0.0);
-
-    generateParticleIDs<gpu>(d.id);
 
     auto cv = sph::idealGasCv(d.muiConst, d.gamma);
 

--- a/main/src/init/turbulence_init.hpp
+++ b/main/src/init/turbulence_init.hpp
@@ -75,7 +75,7 @@ InitSettings TurbulenceConstants()
 
 //! @brief init particle data fields. Note: Dataset attributes must be initialized
 template<class Dataset>
-void initTurbulenceHydroFields(Dataset& d, const std::map<std::string, double>& constants)
+void initTurbulenceHydroFields(Dataset& d, const InitSettings& constants)
 {
     constexpr bool gpu   = cstone::HaveGpu<typename Dataset::AcceleratorType>{};
     double         mPart = constants.at("mTotal") / d.numParticlesGlobal;
@@ -85,22 +85,10 @@ void initTurbulenceHydroFields(Dataset& d, const std::map<std::string, double>& 
     auto cv    = sph::idealGasCv(d.muiConst, d.gamma);
     auto temp0 = constants.at("u0") / cv;
 
-    cstone::fill<gpu>(d.m.begin(), d.m.end(), mPart);
-    cstone::fill<gpu>(d.du_m1.begin(), d.du_m1.end(), 0.0);
-    cstone::fill<gpu>(d.h.begin(), d.h.end(), hInit);
-    cstone::fill<gpu>(d.mui.begin(), d.mui.end(), d.muiConst);
-    cstone::fill<gpu>(d.alpha.begin(), d.alpha.end(), d.alphamin);
+    initFieldsAtRest(d, mPart);
     cstone::fill<gpu>(d.temp.begin(), d.temp.end(), temp0);
     cstone::fill<gpu>(d.u.begin(), d.u.end(), constants.at("u0"));
-
-    cstone::fill<gpu>(d.vx.begin(), d.vx.end(), 0.);
-    cstone::fill<gpu>(d.vy.begin(), d.vy.end(), 0.);
-    cstone::fill<gpu>(d.vz.begin(), d.vz.end(), 0.);
-    cstone::fill<gpu>(d.x_m1.begin(), d.x_m1.end(), 0.);
-    cstone::fill<gpu>(d.y_m1.begin(), d.y_m1.end(), 0.);
-    cstone::fill<gpu>(d.z_m1.begin(), d.z_m1.end(), 0.);
-
-    generateParticleIDs<gpu>(d.id);
+    cstone::fill<gpu>(d.h.begin(), d.h.end(), hInit);
 }
 
 template<class Dataset>

--- a/main/src/init/utils.hpp
+++ b/main/src/init/utils.hpp
@@ -143,6 +143,29 @@ void generateParticleIDs(std::span<uint64_t> id)
     cstone::sequenceAcc<gpu>(id.data(), id.data() + id.size(), ranksLocalParticles[rank]);
 }
 
+template<class Dataset>
+void initFieldsAtRest(Dataset& d, double m_part)
+{
+    constexpr bool gpu = cstone::HaveGpu<typename Dataset::AcceleratorType>{};
+
+    cstone::fill<gpu>(d.m.begin(), d.m.end(), m_part);
+    cstone::fill<gpu>(d.du_m1.begin(), d.du_m1.end(), 0.0);
+    cstone::fill<gpu>(d.mui.begin(), d.mui.end(), d.muiConst);
+    cstone::fill<gpu>(d.alpha.begin(), d.alpha.end(), d.alphamin);
+
+    cstone::fill<gpu>(d.vx.begin(), d.vx.end(), 0.0);
+    cstone::fill<gpu>(d.vy.begin(), d.vy.end(), 0.0);
+    cstone::fill<gpu>(d.vz.begin(), d.vz.end(), 0.0);
+    cstone::fill<gpu>(d.x_m1.begin(), d.x_m1.end(), 0.0);
+    cstone::fill<gpu>(d.y_m1.begin(), d.y_m1.end(), 0.0);
+    cstone::fill<gpu>(d.z_m1.begin(), d.z_m1.end(), 0.0);
+
+    cstone::fill<gpu>(d.u.begin(), d.u.end(), 0.0);
+    cstone::fill<gpu>(d.temp.begin(), d.temp.end(), 0.0);
+
+    generateParticleIDs<gpu>(d.id);
+}
+
 //! @brief Used to read the default values of dataset attributes
 class BuiltinReader
 {

--- a/main/src/init/wind_shock_init.hpp
+++ b/main/src/init/wind_shock_init.hpp
@@ -61,8 +61,8 @@ template<class Dataset>
 void initWindShockFields(Dataset& d, const std::map<std::string, double>& constants, double massPart)
 {
     constexpr bool gpu = cstone::HaveGpu<typename Dataset::AcceleratorType>{};
-    using T            = typename Dataset::RealType;
-    using HydroType    = typename Dataset::HydroType;
+    using T            = Dataset::RealType;
+    using HydroType    = Dataset::HydroType;
 
     T r       = constants.at("r");
     T rSphere = constants.at("rSphere");
@@ -78,13 +78,7 @@ void initWindShockFields(Dataset& d, const std::map<std::string, double>& consta
     T hExt = 0.5 * std::cbrt(3. * d.ng0 * massPart / 4. / M_PI / rhoExt);
 
     auto cv = sph::idealGasCv(d.muiConst, d.gamma);
-
-    cstone::fill<gpu>(d.m.begin(), d.m.end(), massPart);
-    cstone::fill<gpu>(d.du_m1.begin(), d.du_m1.end(), 0.0);
-    cstone::fill<gpu>(d.mui.begin(), d.mui.end(), d.muiConst);
-    cstone::fill<gpu>(d.alpha.begin(), d.alpha.end(), d.alphamin);
-
-    generateParticleIDs<gpu>(d.id);
+    initFieldsAtRest(d, massPart);
 
     T uInt = uExt / (rhoInt / rhoExt);
 


### PR DESCRIPTION
Just a minor cleanup.

Kelvin-Helmoltz: `alpha` is now initialized with `alphamin`, like all the other initializers.
Per @rmcabezon, this is formally the correct choice with AV switches. On actual results,
we expect almost no effects as the values will be quickly adjusted at the beginning while the
time-steps are still small.