### PR TITLE
Fix Compiler Warnings and Treat Warnings as Errors by Default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,7 @@ cmake_minimum_required(VERSION 3.24)
 
 project(sphexa CXX C)
 set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_COMPILE_WARNING_AS_ERROR OFF)
 
 set(CMAKE_CXX_FLAGS_RELEASE "-O3 -march=native -DNDEBUG")
 set(CMAKE_CUDA_FLAGS_RELEASE "-O3 -DNDEBUG")
@@ -97,11 +98,15 @@ if (SPH_EXA_WITH_H5HUT)
       set(SPH_EXA_WITH_H5HUT OFF)
     endif ()
 endif ()
-
-option(SPH_EXA_WITH_GRACKLE "Enable radiative cooling with GRACKLE" OFF)
 if (SPH_EXA_WITH_GRACKLE)
     add_subdirectory(extern/grackle)
 endif()
+
+# HIP targets expose their headers as plain -I (not -isystem), so handling warnings as errors prohibits compilation
+if (NOT SPH_EXA_WITH_HIP)
+    set(CMAKE_COMPILE_WARNING_AS_ERROR ON)
+endif()
+add_compile_options(-Wall -Wextra $<$<COMPILE_LANGUAGE:CUDA>:-Wno-unknown-pragmas>)
 
 option(SPH_EXA_WITH_DISKS "Enable disk physics and propagator" OFF)
 option(SPH_EXA_WITH_TDE_INIT "Enable TDE initializers" OFF)

--- a/domain/test/coord_samples/random.cpp
+++ b/domain/test/coord_samples/random.cpp
@@ -43,7 +43,6 @@ TEST(CoordinateSamples, randomMixDContainerIsSorted)
     Box<real> box{-240, 480, 0, 512, 0, 1};
     RandomCoordinates<real, SfcKind<IntegerType>> c(n, box);
 
-    const auto axesBits = box.getBoxDimBits(maxTreeLevel<IntegerType>{});
     std::vector<IntegerType> testCodes(n);
     computeSfcKeys(c.x().data(), c.y().data(), c.z().data(), sfcKindPointer(testCodes.data()), n, box);
 

--- a/main/src/init/file_init.hpp
+++ b/main/src/init/file_init.hpp
@@ -99,9 +99,9 @@ class FileInit : public ISimInitializer<Dataset>
 
 public:
     explicit FileInit(const std::string& fname, int initStep_, IFileReader* reader)
-        : h5_fname(fname)
+        : ISimInitializer<Dataset>(fname)
+        , h5_fname(fname)
         , initStep(initStep_)
-        , ISimInitializer<Dataset>(fname)
     {
         // Read file attributes and put them in settings_ such that they propagate to the new output after a restart
         readFileAttributes(settings_, h5_fname, reader, false);
@@ -128,9 +128,9 @@ class FileSplitInit : public ISimInitializer<Dataset>
 
 public:
     explicit FileSplitInit(const std::string& fname, int numSplits_, IFileReader* reader)
-        : h5_fname(fname)
+        : ISimInitializer<Dataset>(fname)
+        , h5_fname(fname)
         , numSplits(numSplits_)
-        , ISimInitializer<Dataset>(fname)
     {
         if (numSplits < 1)
         {

--- a/main/src/init/gresho_chan.hpp
+++ b/main/src/init/gresho_chan.hpp
@@ -124,8 +124,8 @@ class GreshoChan : public ISimInitializer<Dataset>
 
 public:
     GreshoChan(std::string initBlock, std::string settingsFile, IFileReader* reader)
-        : glassBlock(std::move(initBlock))
-        , ISimInitializer<Dataset>(settingsFile)
+        : ISimInitializer<Dataset>(settingsFile)
+        , glassBlock(std::move(initBlock))
     {
         Dataset d;
         settings_ = buildSettings(d, GreshoChanSettings(), settingsFile, reader);

--- a/main/src/init/isim_init.hpp
+++ b/main/src/init/isim_init.hpp
@@ -90,7 +90,7 @@ private:
             selSpheres.resize(numSpheres4 / IdSelectionSphere{}.size());
             reader->fileAttribute(idTagFsStrings[0], selSpheres.data()->data(), numSpheres4);
 
-            if (reader->fileAttributeSize(idTagFsStrings[1]) != selSpheres.size())
+            if (reader->fileAttributeSize(idTagFsStrings[1]) != static_cast<int64_t>(selSpheres.size()))
                 throw std::runtime_error("number of selection spheres != number of sphere ids");
             sphereGroupIds.resize(selSpheres.size());
             reader->fileAttribute(std::string(idTagFsStrings[1]), sphereGroupIds.data(), selSpheres.size());

--- a/main/src/init/isobaric_cube_init.hpp
+++ b/main/src/init/isobaric_cube_init.hpp
@@ -164,8 +164,8 @@ class IsobaricCubeGlass : public ISimInitializer<Dataset>
 
 public:
     explicit IsobaricCubeGlass(std::string initBlock, std::string settingsFile, IFileReader* reader)
-        : glassBlock(std::move(initBlock))
-        , ISimInitializer<Dataset>(settingsFile)
+        : ISimInitializer<Dataset>(settingsFile)
+        , glassBlock(std::move(initBlock))
     {
         Dataset d;
         settings_ = buildSettings(d, IsobaricCubeConstants(), settingsFile, reader);

--- a/main/src/init/kelvin_helmholtz_init.hpp
+++ b/main/src/init/kelvin_helmholtz_init.hpp
@@ -137,8 +137,8 @@ class KelvinHelmholtzGlass : public ISimInitializer<Dataset>
 
 public:
     KelvinHelmholtzGlass(std::string initBlock, std::string settingsFile, IFileReader* reader)
-        : glassBlock(initBlock)
-        , ISimInitializer<Dataset>(settingsFile)
+        : ISimInitializer<Dataset>(settingsFile)
+        , glassBlock(initBlock)
     {
         Dataset d;
         settings_ = buildSettings(d, KelvinHelmholtzConstants(), settingsFile, reader);

--- a/main/src/init/noh_init.hpp
+++ b/main/src/init/noh_init.hpp
@@ -120,8 +120,8 @@ class NohGlassSphere : public ISimInitializer<Dataset>
 
 public:
     NohGlassSphere(std::string initBlock, std::string settingsFile, IFileReader* reader)
-        : glassBlock(std::move(initBlock))
-        , ISimInitializer<Dataset>(settingsFile)
+        : ISimInitializer<Dataset>(settingsFile)
+        , glassBlock(std::move(initBlock))
     {
         Dataset d;
         settings_ = buildSettings(d, nohConstants(), settingsFile, reader);

--- a/main/src/init/radial_profile.hpp
+++ b/main/src/init/radial_profile.hpp
@@ -104,8 +104,8 @@ protected:
 public:
     explicit RadialProfile(std::string initBlock, const InitSettings& testCaseSettings, std::string settingsFile,
                            IFileReader* reader)
-        : glassBlock_(std::move(initBlock))
-        , ISimInitializer<Dataset>(settingsFile)
+        : ISimInitializer<Dataset>(settingsFile)
+        , glassBlock_(std::move(initBlock))
     {
         Dataset d;
         settings_ = buildSettings(d, testCaseSettings, settingsFile, reader);

--- a/main/src/init/sedov_init.hpp
+++ b/main/src/init/sedov_init.hpp
@@ -145,8 +145,8 @@ class SedovGlass : public ISimInitializer<Dataset>
 
 public:
     SedovGlass(std::string initBlock, std::string settingsFile, IFileReader* reader)
-        : glassBlock(std::move(initBlock))
-        , ISimInitializer<Dataset>(settingsFile)
+        : ISimInitializer<Dataset>(settingsFile)
+        , glassBlock(std::move(initBlock))
     {
         Dataset d;
         settings_ = buildSettings(d, sedovConstants(), settingsFile, reader);

--- a/main/src/init/turbulence_init.hpp
+++ b/main/src/init/turbulence_init.hpp
@@ -98,8 +98,8 @@ class TurbulenceGlass : public ISimInitializer<Dataset>
 
 public:
     explicit TurbulenceGlass(std::string initBlock, std::string settingsFile, IFileReader* reader)
-        : glassBlock(std::move(initBlock))
-        , ISimInitializer<Dataset>(settingsFile)
+        : ISimInitializer<Dataset>(settingsFile)
+        , glassBlock(std::move(initBlock))
     {
         Dataset d;
         settings_ = buildSettings(d, TurbulenceConstants(), settingsFile, reader);

--- a/main/src/init/wind_shock_init.hpp
+++ b/main/src/init/wind_shock_init.hpp
@@ -147,8 +147,8 @@ class WindShockGlass : public ISimInitializer<Dataset>
 
 public:
     WindShockGlass(std::string initBlock, std::string settingsFile, IFileReader* reader)
-        : glassBlock(std::move(initBlock))
-        , ISimInitializer<Dataset>(settingsFile)
+        : ISimInitializer<Dataset>(settingsFile)
+        , glassBlock(std::move(initBlock))
     {
         Dataset d;
         settings_ = buildSettings(d, WindShockConstants(), settingsFile, reader);

--- a/physics/Disk/include/central_force_gpu.cu
+++ b/physics/Disk/include/central_force_gpu.cu
@@ -75,9 +75,8 @@ void computeCentralForceGPU(size_t first, size_t last, const Treal* x, const Tre
     checkGpuErrors(cudaMemcpyToSymbol(GPU_SYMBOL(force_device), &force_local, sizeof(force_local)));
     checkGpuErrors(cudaMemcpyToSymbol(GPU_SYMBOL(t_star_device), &t_star_local, sizeof(t_star_local)));
 
-    const double         inner_size2 = star.inner_size * star.inner_size;
-    CentralPotentialData data{x, y, z, m, ax, ay, az, g, star.m, inner_size2, 1.0};
-    data.star_position = star.position; // Initializing in aggregate list produces an error
+    const double                               inner_size2 = star.inner_size * star.inner_size;
+    CentralPotentialData<Treal, Thydro, Tmass> data{x, y, z, m, ax, ay, az, g, star.m, inner_size2, 1.0, star.position};
     if (last > first)
     {
         computeCentralForceGPUKernel<numThreads><<<numBlocks, numThreads>>>(first, last, data, star.potentialType);


### PR DESCRIPTION
- Uses `-Wall -Wextra` by default and sets `CMAKE_WARNING_AS_ERROR`.
- Treating warnings as errors can still be disabled by `cmake --compile-no-warning-as-error`.
- HIP is currently excluded because it wrongly uses `-I` instead of `-isystem` for its includes and triggers compilation failure.