### PR TITLE
Don’t Treat Compiler Warning as Errors by Default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -103,7 +103,7 @@ if (SPH_EXA_WITH_GRACKLE)
 endif()
 
 # HIP targets expose their headers as plain -I (not -isystem), so handling warnings as errors prohibits compilation
-if (NOT SPH_EXA_WITH_HIP)
+if ((NOT SPH_EXA_WITH_HIP) AND (DEFINED ENV{SPH_EXA_WARNING_AS_ERROR}))
     set(CMAKE_COMPILE_WARNING_AS_ERROR ON)
 endif()
 add_compile_options(-Wall -Wextra $<$<COMPILE_LANGUAGE:CUDA>:-Wno-unknown-pragmas>)

--- a/ci/cuda13/build_debug_sm90.yml
+++ b/ci/cuda13/build_debug_sm90.yml
@@ -28,6 +28,7 @@ sph-build-cuda13-sm90-debug:
     - 'export PATH=$PWD/uenv-spack.git:$PATH'
     - 'export SPACK_SYSTEM_CONFIG_PATH=$UENV_SPACK_CONFIG_PATH'
     - echo "SPACK_SYSTEM_CONFIG_PATH=$SPACK_SYSTEM_CONFIG_PATH"
+    - 'export SPH_EXA_WARNING_AS_ERROR=1'
     - pwd
     - 'uenv-spack --uarch=gh200 --specs="sphexa@$CI_COMMIT_SHORT_SHA +disks +cuda +grackle cuda_arch=90 build_type=Debug" --name=sphexa sphexa+spack'
   script:

--- a/ci/cuda13/build_release_sm90.yml
+++ b/ci/cuda13/build_release_sm90.yml
@@ -28,6 +28,7 @@ sph-build-cuda13-sm90-release:
     - 'export PATH=$PWD/uenv-spack.git:$PATH'
     - 'export SPACK_SYSTEM_CONFIG_PATH=$UENV_SPACK_CONFIG_PATH'
     - echo "SPACK_SYSTEM_CONFIG_PATH=$SPACK_SYSTEM_CONFIG_PATH"
+    - 'export SPH_EXA_WARNING_AS_ERROR=1'
     - pwd
     - 'uenv-spack --uarch=gh200 --specs="sphexa@$CI_COMMIT_SHORT_SHA +disks +cuda +grackle cuda_arch=90 build_type=Release" --name=sphexa sphexa+spack'
   script:


### PR DESCRIPTION
Only set `CMAKE_COMPILE_WARNING_AS_ERROR` if `SPH_EXA_WARNING_AS_ERROR` is found in the CMake environment. 