### PR TITLE
Improved Iterative Smoothing Length Update on Convergence Failure

### DIFF
--- a/domain/include/cstone/findneighbors.hpp
+++ b/domain/include/cstone/findneighbors.hpp
@@ -34,24 +34,6 @@ constexpr std::remove_cvref_t<std::remove_pointer_t<T>> loadAtIndexIfPtr(T ptrOr
         return ptrOrValue;
 }
 
-/*! @brief Turns h values into an invalid signalling value used to indicate unconverged neighbor searches
- *
- * Current choice of infinity is transparent to timesteps and SPH kernels, but must be converted to zero in overlaps
- * and neighbor searches.
- */
-template<class T>
-constexpr T invalidateH(T /*value*/)
-{
-    return std::numeric_limits<T>::infinity();
-}
-
-//! @brief Return 0 if @p value is invalid according to invalidateH, unmodified @p value otherwise
-template<class T>
-constexpr T invalidHToZero(T value)
-{
-    return value == invalidateH(value) ? 0 : value;
-}
-
 /*! @brief compute squared distance, taking PBC into account
  *
  * Note that if pbc{X,Y,Z} is false, the result is identical to distancesq below.
@@ -116,7 +98,7 @@ HOST_DEVICE_FUN unsigned findNeighbors(LocalIndex i,
     Tc xi    = x[i];
     Tc yi    = y[i];
     Tc zi    = z[i];
-    Th hi    = invalidHToZero(loadAtIndexIfPtr(h, i));
+    Th hi    = loadAtIndexIfPtr(h, i);
 
     auto radiusSq     = Th(4.0) * hi * hi;
     auto cellRadiusSq = radiusSq * tree.searchExtFactor * tree.searchExtFactor;

--- a/domain/include/cstone/traversal/ijloop/common.hpp
+++ b/domain/include/cstone/traversal/ijloop/common.hpp
@@ -78,8 +78,7 @@ inline constexpr bool requiresPbcHandling(Box<Tc> const& box, std::tuple<LocalIn
         (box.boundaryZ() != BoundaryType::periodic))
         return false;
     const Vec3<Tc>& iPos = std::get<1>(iData);
-    const Th hi          = invalidHToZero(std::get<2>(iData));
-    const Tc twoHi       = Tc(2) * hi;
+    const Tc twoHi       = Tc(2) * std::get<2>(iData);
     return !insideBox(iPos, {twoHi, twoHi, twoHi}, box);
 }
 

--- a/domain/include/cstone/traversal/ijloop/gpu_superclusternblist/build.cuh
+++ b/domain/include/cstone/traversal/ijloop/gpu_superclusternblist/build.cuh
@@ -563,8 +563,8 @@ __global__ __launch_bounds__(GpuConfig::warpSize* NumSuperclustersPerBlock) void
         SuperclusterInfo info = {.index = index + firstISupercluster, .neighborsCount = 0, .dataIndex = 0};
 
         const unsigned jClusterBytes = collectNeighborJClusters<Config, UsePbc>(
-            tree, box, firstValidBody, totalBodies, x, y, z, h, jClusterBboxes, nodeRMax, ncmax,
-            firstISupercluster, lastISupercluster, jClusters, masks, info);
+            tree, box, firstValidBody, totalBodies, x, y, z, h, jClusterBboxes, nodeRMax, ncmax, firstISupercluster,
+            lastISupercluster, jClusters, masks, info);
         maxNeighbors = std::max(info.neighborsCount, maxNeighbors);
 
         if (info.neighborsCount > ncmax && laneIdx == 0) globalBuildData->status = BuildStatus::neighbor_list_overflow;

--- a/domain/include/cstone/traversal/ijloop/gpu_superclusternblist/build.cuh
+++ b/domain/include/cstone/traversal/ijloop/gpu_superclusternblist/build.cuh
@@ -141,7 +141,7 @@ __global__ void computeJClusterBboxesKernel(const LocalIndex firstValidBody,
     if constexpr (Config::symmetric)
     {
         using Th    = std::remove_cvref_t<std::remove_pointer_t<ThP>>;
-        const Th hi = invalidHToZero(loadAtIndexIfPtr(h, std::max(std::min(i, totalBodies - 1), firstValidBody)));
+        const Th hi = loadAtIndexIfPtr(h, std::max(std::min(i, totalBodies - 1), firstValidBody));
         Th rMax     = 2 * hi;
 
 #pragma unroll
@@ -250,7 +250,7 @@ __device__ __forceinline__ auto loadSuperclusterParticleData(const LocalIndex fi
     {
         const unsigned i = std::min(firstBody + w * GpuConfig::warpSize + laneIdx, lastBody - 1);
         iPos[w]          = {x[i], y[i], z[i]};
-        iRadius[w]       = 2 * invalidHToZero(loadAtIndexIfPtr(h, i)) * searchExtFactor;
+        iRadius[w]       = 2 * loadAtIndexIfPtr(h, i) * searchExtFactor;
     }
     return std::make_tuple(iPos, iRadius);
 }
@@ -422,8 +422,7 @@ collectNeighborJClusters(const OctreeNsView<Tc, KeyType>& tree,
                     const LocalIndex j =
                         std::clamp(jCluster * Config::jSize + jClusterParticle, firstValidBody, totalBodies - 1);
                     const Vec3<Tc> jPos = {x[j], y[j], z[j]};
-                    Th jRadius =
-                        Config::symmetric ? 2 * invalidHToZero(loadAtIndexIfPtr(h, j)) * tree.searchExtFactor : Th(0);
+                    const Th jRadius    = Config::symmetric ? 2 * loadAtIndexIfPtr(h, j) * tree.searchExtFactor : Th(0);
                     const unsigned warpIndex = jClusterParticle / (Config::jSize / Config::numWarpsPerInteraction);
 
                     for (unsigned w = 0; w < warpsPerSupercluster; ++w)

--- a/domain/include/cstone/traversal/ijloop/gpu_superclusternblist/loop.cuh
+++ b/domain/include/cstone/traversal/ijloop/gpu_superclusternblist/loop.cuh
@@ -227,11 +227,9 @@ inline constexpr auto splitParticleDataWithRadiusSq(std::tuple<Tc, Tc, Tc, Ts...
     }
 
     constexpr std::size_t skip = std::is_pointer_v<ThP> ? 2 : 0;
-    auto iData                 = [&]<std::size_t... Is>(std::index_sequence<Is...>)
-    {
+    auto iData                 = [&]<std::size_t... Is>(std::index_sequence<Is...>) {
         return std::make_tuple(index, iPos, hi, std::get<Is + 3 + skip>(particleDataWithRadiusSq)...);
-    }
-    (std::make_index_sequence<sizeof...(Ts) - skip>());
+    }(std::make_index_sequence<sizeof...(Ts) - skip>());
 
     return std::make_tuple(iData, radiusSq);
 }

--- a/domain/include/cstone/traversal/ijloop/gpu_superclusternblist/loop.cuh
+++ b/domain/include/cstone/traversal/ijloop/gpu_superclusternblist/loop.cuh
@@ -371,7 +371,7 @@ __global__ __launch_bounds__(Config::iSize* Config::jSize* NumSuperclustersPerBl
             auto jData                   = (nb < iSuperclusterNeighborsCount & j >= firstValidBody & j < totalBodies)
                                                ? loadParticleData(x, y, z, h, input, j)
                                                : dummyParticleData(x, y, z, h, input, j);
-            const Th jRadiusSq           = invalidHToZero(radiusSq(jData));
+            const Th jRadiusSq           = radiusSq(jData);
             std::get<0>(jData) -= firstValidBody;
             Result jResult = {};
 
@@ -380,22 +380,21 @@ __global__ __launch_bounds__(Config::iSize* Config::jSize* NumSuperclustersPerBl
                 const unsigned i = iSupercluster * Config::superclusterSize + c * Config::iSize + threadIdx.x;
                 if ((warpMask >> c) & (!Config::symmetric | (iSupercluster != jSupercluster) | (i <= j)))
                 {
-                    const bool ijEq = i == j;
-                    auto [iData, iRadiusSq] =
+                    const bool jRequired = i != j;
+                    const auto [iData, iRadiusSq] =
                         getIData(iSuperclusterData, c * Config::iSize + threadIdx.x, i - firstValidBody, h);
                     assert(std::get<0>(iData) == i - firstValidBody);
-                    iRadiusSq                      = invalidHToZero(iRadiusSq);
                     const auto [ijPosDiff, distSq] = posDiffAndDistSq(UsePbc, box, iData, jData);
                     bool iClose, jClose;
                     if constexpr (std::is_pointer_v<ThP>)
                     {
-                        iClose = distSq < iRadiusSq | ijEq;
-                        jClose = Config::symmetric && (distSq < jRadiusSq & !ijEq);
+                        iClose = distSq < iRadiusSq;
+                        jClose = Config::symmetric && (distSq < jRadiusSq & jRequired);
                     }
                     else
                     {
-                        iClose = distSq < jRadiusSq | ijEq;
-                        jClose = Config::symmetric && (iClose & !ijEq);
+                        iClose = distSq < jRadiusSq;
+                        jClose = Config::symmetric && (iClose & jRequired);
                     }
                     if (iClose | jClose)
                     {

--- a/domain/include/cstone/traversal/ijloop/upsweep.cuh
+++ b/domain/include/cstone/traversal/ijloop/upsweep.cuh
@@ -141,8 +141,7 @@ computeNodeRMax(const execution::Gpu exec, const OctreeNsView<Tc, KeyType>& tree
     {
         nodeRMax = util::deviceAlloc<Th[]>(exec, tree.numNodes);
         upsweep(
-            exec, tree, std::tuple(Th(0)),
-            [] __device__(auto h) { return std::make_tuple(2 * invalidHToZero(std::get<0>(h))); },
+            exec, tree, std::tuple(Th(0)), [] __device__(auto h) { return std::make_tuple(2 * std::get<0>(h)); },
             [] __device__(auto accum, auto r) { return std::make_tuple(std::max(std::get<0>(accum), std::get<0>(r))); },
             std::tuple(h), std::tuple(nodeRMax.get()));
     }

--- a/sph/include/sph/find_neighbors_gpu.cu
+++ b/sph/include/sph/find_neighbors_gpu.cu
@@ -80,6 +80,8 @@ void updateSmoothingLengthIterativeGpu(const cstone::GroupView& grp, Dataset& d,
 
     updateSmoothingLengthIterativeGpuKernel<<<numBlocks, numThreads>>>(
         grp, d.ng0, d.ngmax, box, d.treeView, rawPtr(d.x), rawPtr(d.y), rawPtr(d.z), rawPtr(d.h), rawPtr(d.nc));
+    checkGpuErrors(cudaGetLastError());
+    checkGpuErrors(cudaDeviceSynchronize());
 }
 
 template void updateSmoothingLengthIterativeGpu(const cstone::GroupView&,

--- a/sph/include/sph/find_neighbors_gpu.cu
+++ b/sph/include/sph/find_neighbors_gpu.cu
@@ -12,8 +12,8 @@ void findNeighborsSfc(const cstone::GroupView& groups, sphexa::ParticlesData<cst
     d.neighborhood.build(groups, d, box, subgroups);
 }
 
-using cstone::GroupView;
 using cstone::GpuConfig;
+using cstone::GroupView;
 using cstone::LocalIndex;
 using cstone::TreeNodeIndex;
 

--- a/sph/include/sph/kernels.hpp
+++ b/sph/include/sph/kernels.hpp
@@ -53,8 +53,14 @@ HOST_DEVICE_FUN void updateHIterative(unsigned ng0, unsigned ngmax, const cstone
 
     if ((ncSph - 1) > ngmax)
     {
-        T        low = T(0), high = h[i];
-        unsigned ncLow = 1;
+        T high = h[i];
+
+        h[i]  = updateH(ng0, ncSph, h[i]);
+        ncSph = 1 + findNeighbors(i, x, y, z, h, treeView, box, ngmax);
+        assert(ncSph <= ng0);
+
+        T        low   = h[i];
+        unsigned ncLow = ncSph;
         for (int iteration = 0; iteration < maxIteration; ++iteration)
         {
             h[i]  = (low + high) / T(2);

--- a/sph/include/sph/kernels.hpp
+++ b/sph/include/sph/kernels.hpp
@@ -65,10 +65,7 @@ HOST_DEVICE_FUN void updateHIterative(unsigned ng0, unsigned ngmax, const cstone
                 low   = h[i];
                 ncLow = ncSph;
             }
-            else
-            {
-                high = h[i];
-            }
+            else { high = h[i]; }
         }
         if ((ncSph - 1) > ngmax)
         {

--- a/sph/include/sph/kernels.hpp
+++ b/sph/include/sph/kernels.hpp
@@ -51,11 +51,34 @@ HOST_DEVICE_FUN void updateHIterative(unsigned ng0, unsigned ngmax, const cstone
         ncSph = 1 + findNeighbors(i, x, y, z, h, treeView, box, ngmax);
     }
 
-    if (ngmin > ncSph || (ncSph - 1) > ngmax)
+    if ((ncSph - 1) > ngmax)
     {
-        ncSph = 1;
-        h[i]  = cstone::invalidateH(h[i]);
+        T        low = T(0), high = h[i];
+        unsigned ncLow = 1;
+        for (int iteration = 0; iteration < maxIteration; ++iteration)
+        {
+            h[i]  = (low + high) / T(2);
+            ncSph = 1 + findNeighbors(i, x, y, z, h, treeView, box, ngmax);
+            if (ncSph == ng0) { break; }
+            else if (ncSph < ng0)
+            {
+                low   = h[i];
+                ncLow = ncSph;
+            }
+            else
+            {
+                high = h[i];
+            }
+        }
+        if ((ncSph - 1) > ngmax)
+        {
+            h[i]  = low;
+            ncSph = ncLow;
+        }
     }
+    assert((ncSph - 1) <= ngmax);
+
+    if (ngmin > ncSph) { ncSph = 1; }
 
     nc[i] = ncSph;
 }


### PR DESCRIPTION
After failure of the normal iterative smoothing length update, this adds a second stage (based on binary search) for the case where more neighbors than `ngmax` have been found. This guarantees that the neighbor count is always capped at `ngmax`. Further, this reverts setting `h[i]` to infinity in non-convergent cases (introduced in #628) and adds a missing device sync to fix reported timings.