### PR TITLE
Add support for GCC/16

### DIFF
--- a/domain/include/cstone/cuda/device_vector.h
+++ b/domain/include/cstone/cuda/device_vector.h
@@ -15,6 +15,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <memory>
 #include <vector>
 


### PR DESCRIPTION
Fix for https://github.com/spack/spack-packages/pull/5342#issuecomment-5225995067

```
In file included from sphexa.git/domain/include/cstone/primitives/primitives_gpu.h:22,
                 from sphexa.git/domain/include/cstone/primitives/primitives_acc.hpp:22,
                 from sphexa.git/domain/include/cstone/fields/field_get.hpp:19,
                 from sphexa.git/physics/cooling/include/cooling/cooler.hpp:43,
                 from sphexa.git/physics/cooling/include/cooling/cooler_impl.hpp:7,
                 from sphexa.git/physics/cooling/include/cooling/cooler.cpp:13:
/users/piccinal/sphexa.git/domain/include/cstone/cuda/device_vector.h:81:36: error: 'uint8_t' was not declared in this scope
   81 | extern template class DeviceVector<uint8_t>;
      |                                    ^~~~~~~
```

Fix tested with GNU versions 14.3.0 and 16.1.0