### PR TITLE
Fix Invalid Value Error on AMD HIP

### DIFF
--- a/domain/include/cstone/halos/exchange_halos_gpu.cuh
+++ b/domain/include/cstone/halos/exchange_halos_gpu.cuh
@@ -111,7 +111,7 @@ void haloExchangeGpu(int epoch,
 
     if (not sendRequests.empty()) { MPI_Waitall(int(sendRequests.size()), sendRequests.data(), MPI_STATUSES_IGNORE); }
 
-    checkGpuErrors(cudaFreeAsync(d_range, exec));
+    if (d_range) checkGpuErrors(cudaFreeAsync(d_range, exec));
     reallocate(sendScratchBuffer, oldSendSize, 1.0);
     reallocate(receiveScratchBuffer, oldRecvSize, 1.0);
 


### PR DESCRIPTION
Fixes `hipErrorInvalidValue` or segmentation fault in `haloExchangeGpu` on AMD HIP (tested with version 6.3) for single-GPU runs (where `d_range` is null, which is happily accepted by `cudaFreeAsync`, but not `hipFreeAsync`).